### PR TITLE
Add SecretPlugin interface and VaultOidc implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,13 @@
         <assertj.version>3.24.2</assertj.version>
         <blt-assertj.version>1.0.1</blt-assertj.version>
         <blt-core.version>1.0.3</blt-core.version>
+        <commons-lang3.version>3.13.0</commons-lang3.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <jackson.version>2.15.3</jackson.version>
         <jakarta-el.version>5.0.0-M1</jakarta-el.version>
         <junit.version>5.10.0</junit.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <wiremock.version>3.0.1</wiremock.version>
     </properties>
 
     <dependencies>
@@ -66,6 +68,11 @@
             <version>${blt-core.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
             <version>${jakarta-el.version}</version>
@@ -78,6 +85,12 @@
 
         <!-- Test dependencies -->
 
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.blt</groupId>
             <artifactId>blt-assertj</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <blt-core.version>1.0.3</blt-core.version>
         <commons-lang3.version>3.13.0</commons-lang3.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
+        <httpcore5.version>5.2.3</httpcore5.version>
         <jackson.version>2.15.3</jackson.version>
         <jakarta-el.version>5.0.0-M1</jakarta-el.version>
         <junit.version>5.10.0</junit.version>
@@ -71,6 +72,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>${httpcore5.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,16 @@
         <junit.version>5.10.0</junit.version>
         <mockito.version>5.6.0</mockito.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <vault-driver.version>5.1.0</vault-driver.version>
         <wiremock.version>3.0.1</wiremock.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.bettercloud</groupId>
+            <artifactId>vault-java-driver</artifactId>
+            <version>${vault-driver.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <jackson.version>2.15.3</jackson.version>
         <jakarta-el.version>5.0.0-M1</jakarta-el.version>
         <junit.version>5.10.0</junit.version>
+        <mockito.version>5.6.0</mockito.version>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <wiremock.version>3.0.1</wiremock.version>
     </properties>
@@ -118,6 +119,18 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 
         <assertj.version>3.24.2</assertj.version>
         <blt-assertj.version>1.0.1</blt-assertj.version>
+        <blt-core.version>1.0.3</blt-core.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <jackson.version>2.15.3</jackson.version>
         <jakarta-el.version>5.0.0-M1</jakarta-el.version>
@@ -58,6 +59,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.blt</groupId>
+            <artifactId>blt-core</artifactId>
+            <version>${blt-core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/src/main/java/io/blt/gregbot/core/plugin/PluginLoader.java
+++ b/src/main/java/io/blt/gregbot/core/plugin/PluginLoader.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.core.plugin;
+
+import io.blt.gregbot.core.properties.Properties;
+import io.blt.gregbot.plugin.Plugin;
+import io.blt.util.Obj;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import static io.blt.util.stream.SingletonCollectors.toOptional;
+
+public class PluginLoader<T extends Plugin> {
+
+    private final List<T> plugins;
+
+    public PluginLoader(Class<T> type) {
+        this.plugins = ServiceLoader.load(type).stream()
+                .map(ServiceLoader.Provider::get)
+                .toList();
+    }
+
+    public T load(Properties.Plugin plugin) throws Exception {
+        return Obj.poke(findPluginOrThrow(plugin), p -> p.load(plugin.properties()));
+    }
+
+    public List<String> plugins() {
+        return plugins.stream()
+                .map(this::pluginType)
+                .toList();
+    }
+
+    private T findPluginOrThrow(Properties.Plugin plugin) {
+        return plugins.stream()
+                .filter(p -> pluginType(p).equals(plugin.type()))
+                .collect(toOptional())
+                .orElseThrow();
+    }
+
+    private String pluginType(T plugin) {
+        return plugin.getClass().getName();
+    }
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/Plugin.java
+++ b/src/main/java/io/blt/gregbot/plugin/Plugin.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+public interface Plugin {
+
+    void load(@NotNull Map<String, String> properties) throws Exception;
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/connector/Connector.java
+++ b/src/main/java/io/blt/gregbot/plugin/connector/Connector.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.connector;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.ObjectUtils.requireNonEmpty;
+
+public class Connector {
+
+    private static final HttpClient CLIENT = HttpClient.newBuilder().build();
+
+    private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
+
+    private final String host;
+
+    public Connector(String host) {
+        requireNonEmpty(host, "'host' must not be empty");
+
+        var lastCharIndex = host.length() - 1;
+        this.host = host.charAt(lastCharIndex) == '/' ? host.substring(0, lastCharIndex) : host;
+    }
+
+    public <T> Result<T> send(HttpRequest request) throws IOException, InterruptedException {
+        return send(request, null);
+    }
+
+    public <T> Result<T> send(HttpRequest request, Class<T> responseType) throws IOException, InterruptedException {
+        var result = CLIENT.send(request, HttpResponse.BodyHandlers.ofByteArray());
+        return new Result<>(result, responseType);
+    }
+
+    public URI uriForPath(String path) {
+        return URI.create(host + (path.charAt(0) == '/' ? path : "/" + path));
+    }
+
+    public static HttpRequest.BodyPublisher formFromMap(Map<String, String> map) {
+        return HttpRequest.BodyPublishers.ofString(mapAsFormDataString(map));
+    }
+
+    private static String mapAsFormDataString(Map<String, String> map) {
+        return map.entrySet().stream()
+                .map(e -> encode(e.getKey()) + "=" + encode(e.getValue()))
+                .collect(Collectors.joining("&"));
+    }
+
+    private static String encode(String string) {
+        return URLEncoder.encode(string, StandardCharsets.UTF_8);
+    }
+
+    public static class Result<T> {
+        private final HttpResponse<byte[]> response;
+        private final T data;
+
+        private Result(HttpResponse<byte[]> response, Class<T> type) {
+            this.response = response;
+            this.data = decodeResponseElseNull(response, type);
+        }
+
+        public HttpResponse<byte[]> getResponse() {
+            return response;
+        }
+
+        public Optional<T> getData() {
+            return Optional.ofNullable(data);
+        }
+
+        private T decodeResponseElseNull(HttpResponse<byte[]> response, Class<T> type) {
+            return nonNull(type) ? tryDecodeAsJson(response, type).orElse(null) : null;
+        }
+
+        private Optional<T> tryDecodeAsJson(HttpResponse<byte[]> response, Class<T> type) {
+            try {
+                return Optional.of(MAPPER.readValue(response.body(), type));
+            } catch (IOException e) {
+                return Optional.empty();
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/secrets/SecretPlugin.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/SecretPlugin.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets;
+
+import io.blt.gregbot.plugin.Plugin;
+import java.util.Map;
+
+public interface SecretPlugin extends Plugin {
+
+    Map<String, String> secretsForPath(String path);
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault;
+
+import io.blt.gregbot.plugin.secrets.SecretPlugin;
+import java.util.Map;
+import java.util.Objects;
+
+public class VaultOidc implements SecretPlugin {
+
+    private String host;
+
+    @Override
+    public void load(Map<String, String> properties) {
+        host = Objects.requireNonNull(properties.get("host"), "must specify 'host' property");
+    }
+
+    @Override
+    public Map<String, String> secretsForPath(String path) {
+        return null;
+    }
+}

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
@@ -8,21 +8,50 @@
 
 package io.blt.gregbot.plugin.secrets.vault;
 
+import com.bettercloud.vault.Vault;
+import com.bettercloud.vault.VaultConfig;
+import com.bettercloud.vault.VaultException;
 import io.blt.gregbot.plugin.secrets.SecretPlugin;
+import io.blt.gregbot.plugin.secrets.vault.connector.VaultConnector;
+import io.blt.gregbot.plugin.secrets.vault.oidc.Oidc;
+import io.blt.gregbot.plugin.secrets.vault.oidc.OidcConfig;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeoutException;
 
 public class VaultOidc implements SecretPlugin {
 
-    private String host;
+    private Vault vault;
 
     @Override
-    public void load(Map<String, String> properties) {
-        host = Objects.requireNonNull(properties.get("host"), "must specify 'host' property");
+    public void load(Map<String, String> properties)
+            throws IOException, InterruptedException, VaultException, TimeoutException {
+        var host = Objects.requireNonNull(properties.get("host"), "must specify 'host' property");
+
+        var connector = new VaultConnector(host);
+
+        var token = new Oidc(new OidcConfig(), connector)
+                .fetchAuthTokenUsingDesktopBrowse();
+
+        vault = new Vault(new VaultConfig()
+                .address(host)
+                .engineVersion(1)
+                .token(token)
+                .build());
+
+        // Ensure the token is good
+        vault.auth().renewSelf();
     }
 
     @Override
     public Map<String, String> secretsForPath(String path) {
-        return null;
+        try {
+            return vault.logical()
+                    .read(path)
+                    .getData();
+        } catch (VaultException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/VaultConnector.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/VaultConnector.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.connector;
+
+import io.blt.gregbot.plugin.connector.Connector;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.AuthUrlRequest;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.AuthUrlResponse;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.CallbackRequest;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.CallbackResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.util.Map;
+import org.apache.hc.core5.net.URIBuilder;
+
+public class VaultConnector extends Connector {
+
+    public VaultConnector(String host) {
+        super(host);
+    }
+
+    public Result<AuthUrlResponse> fetchAuthUrl(AuthUrlRequest authUrlRequest) throws IOException {
+        var request = HttpRequest.newBuilder()
+                .uri(uriForPath("/v1/auth/" + authUrlRequest.mount() + "/oidc/auth_url"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(formFromMap(Map.of(
+                        "role", authUrlRequest.role(),
+                        "redirect_uri", authUrlRequest.redirectUrl(),
+                        "client_nonce", authUrlRequest.clientNonce())))
+                .build();
+
+        try {
+            return send(request, AuthUrlResponse.class);
+        } catch (InterruptedException e) {
+            throw new IOException(e);
+        }
+    }
+
+    public Result<CallbackResponse> fetchCallback(CallbackRequest callbackRequest) throws IOException {
+        var uri = new URIBuilder(uriForPath("/v1/auth/" + callbackRequest.mount() + "/oidc/callback"))
+                .addParameter("state", callbackRequest.state())
+                .addParameter("code", callbackRequest.code())
+                .addParameter("id_token", callbackRequest.idToken())
+                .addParameter("client_nonce", callbackRequest.clientNonce())
+                .toString();
+
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create(uri))
+                .GET()
+                .build();
+
+        try {
+            return send(request, CallbackResponse.class);
+        } catch (InterruptedException e) {
+            throw new IOException(e);
+        }
+    }
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/dto/AuthUrlRequest.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/dto/AuthUrlRequest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.connector.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AuthUrlRequest(String mount, String role, String redirectUrl, String clientNonce) {}

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/dto/AuthUrlResponse.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/dto/AuthUrlResponse.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.connector.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AuthUrlResponse(
+        String requestId,
+        String leaseId,
+        boolean renewable,
+        int leastDuration,
+        Data data,
+        Object wrapInfo,
+        Object warnings,
+        Object auth) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record Data(String authUrl) {}
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/dto/CallbackRequest.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/dto/CallbackRequest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.connector.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record CallbackRequest(String mount, String state, String code, String idToken, String clientNonce) {}

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/dto/CallbackResponse.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/dto/CallbackResponse.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.connector.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record CallbackResponse(Auth auth) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record Auth(String clientToken) {}
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/oidc/Oidc.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/oidc/Oidc.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.oidc;
+
+import io.blt.gregbot.plugin.secrets.vault.connector.VaultConnector;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.AuthUrlRequest;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.AuthUrlResponse;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.CallbackRequest;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.CallbackResponse;
+import io.blt.util.functional.ThrowingConsumer;
+import java.awt.Desktop;
+import java.io.IOException;
+import java.net.URI;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hc.core5.net.URIBuilder;
+
+public class Oidc {
+
+    private final OidcConfig config;
+    private final VaultConnector connector;
+
+    public Oidc(OidcConfig config, VaultConnector connector) {
+        this.config = config;
+        this.connector = connector;
+    }
+
+    public String fetchAuthTokenUsingDesktopBrowse() throws IOException, InterruptedException, TimeoutException {
+        return fetchAuthToken(uri -> Desktop.getDesktop().browse(uri));
+    }
+
+    public String fetchAuthToken(ThrowingConsumer<URI, IOException> fetchAuth)
+            throws IOException, InterruptedException, TimeoutException {
+        var nonce = generateNonce();
+        var authUrl = fetchAuthURL(nonce);
+        return listenForToken(nonce, authUrl, fetchAuth);
+    }
+
+    private String generateNonce() {
+        return UUID.randomUUID().toString();
+    }
+
+    private String fetchAuthURL(String nonce) throws IOException {
+        var result = connector.fetchAuthUrl(
+                new AuthUrlRequest(
+                        config.getMount(),
+                        config.getRole(),
+                        buildRedirectUrl(),
+                        nonce));
+
+        return result.getData()
+                .map(AuthUrlResponse::data)
+                .map(AuthUrlResponse.Data::authUrl)
+                .orElseThrow(() -> new IllegalStateException("Failed to fetch Vault auth URL"));
+    }
+
+    private String buildRedirectUrl() {
+        return new URIBuilder()
+                .setScheme(config.getCallbackScheme())
+                .setHost(config.getCallbackHost())
+                .setPort(config.getCallbackPort())
+                .setPath(config.getCallbackPath())
+                .toString();
+    }
+
+    private String listenForToken(String nonce, String authUrl, ThrowingConsumer<URI, IOException> fetchAuth)
+            throws IOException, InterruptedException, TimeoutException {
+        var token = new AtomicReference<String>();
+
+        var listener = new OidcHttpListener(
+                config.getListenHost(),
+                config.getListenPort(),
+                config.getListenPath(), request -> {
+            var result = connector.fetchCallback(new CallbackRequest(
+                    config.getMount(),
+                    request.state(),
+                    request.code(),
+                    request.idToken(),
+                    nonce
+            ));
+
+            token.set(result.getData()
+                    .map(CallbackResponse::auth)
+                    .map(CallbackResponse.Auth::clientToken)
+                    .orElseThrow());
+        });
+
+        fetchAuth.accept(URI.create(authUrl));
+
+        if (!listener.await(config.getListenTimeout())) {
+            throw new TimeoutException(
+                    "Timeout of " + config.getListenTimeout() + " seconds expired while waiting for callback");
+        }
+
+        return token.get();
+    }
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcConfig.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcConfig.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.oidc;
+
+public class OidcConfig {
+    private String role = "";
+    private String mount = "oidc";
+    private String listenHost = "localhost";
+    private int listenPort = 8250;
+    private String listenPath = "/" + mount + "/callback";
+    private int listenTimeout = 10;
+    private String callbackScheme = "http";
+    private String callbackHost = listenHost;
+    private int callbackPort = listenPort;
+    private String callbackPath = listenPath;
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getMount() {
+        return mount;
+    }
+
+    public void setMount(String mount) {
+        this.mount = mount;
+    }
+
+    public String getListenHost() {
+        return listenHost;
+    }
+
+    public void setListenHost(String listenHost) {
+        this.listenHost = listenHost;
+    }
+
+    public int getListenPort() {
+        return listenPort;
+    }
+
+    public void setListenPort(int listenPort) {
+        this.listenPort = listenPort;
+    }
+
+    public String getListenPath() {
+        return listenPath;
+    }
+
+    public void setListenPath(String listenPath) {
+        this.listenPath = listenPath;
+    }
+
+    public int getListenTimeout() {
+        return listenTimeout;
+    }
+
+    public void setListenTimeout(int listenTimeout) {
+        this.listenTimeout = listenTimeout;
+    }
+
+    public String getCallbackScheme() {
+        return callbackScheme;
+    }
+
+    public void setCallbackScheme(String callbackScheme) {
+        this.callbackScheme = callbackScheme;
+    }
+
+    public int getCallbackPort() {
+        return callbackPort;
+    }
+
+    public void setCallbackPort(int callbackPort) {
+        this.callbackPort = callbackPort;
+    }
+
+    public String getCallbackHost() {
+        return callbackHost;
+    }
+
+    public void setCallbackHost(String callbackHost) {
+        this.callbackHost = callbackHost;
+    }
+
+    public String getCallbackPath() {
+        return callbackPath;
+    }
+
+    public void setCallbackPath(String callbackPath) {
+        this.callbackPath = callbackPath;
+    }
+}

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcHttpListener.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcHttpListener.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.oidc;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.net.URIBuilder;
+
+public class OidcHttpListener {
+
+    @FunctionalInterface
+    public interface RequestConsumer {
+        record Request(String state, String code, String idToken) {}
+        void accept(Request request) throws IOException;
+    }
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private final RequestConsumer requestConsumer;
+    private final byte[] successResponse;
+    private final HttpServer server;
+
+    public OidcHttpListener(
+            String hostname, int port, String path, RequestConsumer requestConsumer) throws IOException {
+        this.requestConsumer = requestConsumer;
+        this.successResponse = loadResource("success.html");
+        this.server = HttpServer.create(new InetSocketAddress(hostname, port), 0);
+        this.server.createContext(path, httpHandler());
+        this.server.start();
+    }
+
+    public boolean await(int timeoutInSeconds) throws InterruptedException {
+        var result = latch.await(timeoutInSeconds, TimeUnit.SECONDS);
+        server.stop(0);
+        return result;
+    }
+
+    private HttpHandler httpHandler() {
+        return exchange -> {
+            try {
+                requestConsumer.accept(parseRequest(exchange));
+                write(exchange, 200, successResponse);
+            } finally {
+                latch.countDown();
+            }
+        };
+    }
+
+    private RequestConsumer.Request parseRequest(HttpExchange exchange) {
+        return buildRequest(paramsToMap(exchange.getRequestURI()));
+    }
+
+    private Map<String, String> paramsToMap(URI uri) {
+        return new URIBuilder(uri)
+                .getQueryParams()
+                .stream()
+                .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
+    }
+
+    private RequestConsumer.Request buildRequest(Map<String, String> params) {
+        return new RequestConsumer.Request(params.get("state"), params.get("code"), params.get("id_token"));
+    }
+
+    private void write(HttpExchange exchange, int code, byte[] response) throws IOException {
+        exchange.sendResponseHeaders(code, response.length);
+        var os = exchange.getResponseBody();
+        os.write(response);
+        os.close();
+    }
+
+    private byte[] loadResource(String filename) throws IOException {
+        try (var resource = OidcHttpListener.class.getResourceAsStream(filename)) {
+            return resource.readAllBytes();
+        }
+    }
+
+}

--- a/src/main/resources/META-INF/services/io.blt.gregbot.plugin.secrets.SecretPlugin
+++ b/src/main/resources/META-INF/services/io.blt.gregbot.plugin.secrets.SecretPlugin
@@ -1,0 +1,1 @@
+io.blt.gregbot.plugin.secrets.vault.VaultOidc

--- a/src/main/resources/io/blt/gregbot/plugin/secrets/vault/oidc/success.html
+++ b/src/main/resources/io/blt/gregbot/plugin/secrets/vault/oidc/success.html
@@ -1,0 +1,115 @@
+<!--
+  ~ Copyright (c) 2023 Mike Cowan.
+  ~
+  ~ This source code is subject to the terms of the GNU General Public
+  ~ License, version 3. If a copy of the GPL was not distributed with this
+  ~ file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+  -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Logged into Vault</title>
+    <script type="text/javascript">
+        window.onload = function () {
+            setTimeout(function () {
+                close();
+            }, 2000);
+        }
+    </script>
+    <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
+    <style>
+        @import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap");
+
+        :root {
+            --white: #fff;
+            --text-clr: #706f6f;
+            --success-clr: #3cb878;
+            --success-hvr: #059249;
+            --error-clr: #fd5664;
+            --error-hvr: #ff0016;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+            font-family: "Open Sans", sans-serif;
+        }
+
+        body {
+            background: linear-gradient(transparent, rgba(0, 0, 0, 0.5));
+            color: var(--text-clr);
+            font-size: 12px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+        }
+
+        .modal {
+            width: 350px;
+            background: var(--white);
+            border-radius: 3px;
+            position: relative;
+            display: block;
+        }
+
+        .modal .body {
+            padding: 35px;
+            text-align: center;
+        }
+
+        .modal .icon {
+            width: 60px;
+            height: 60px;
+            border-radius: 50%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            margin: 0 auto 15px;
+            fill: none;
+            stroke: var(--white);
+            stroke-linecap: round;
+            stroke-linejoin: round;
+            stroke-width: 16px
+        }
+
+        .modal.success .icon {
+            background: var(--success-clr);
+        }
+
+        .modal.error .icon {
+            background: var(--error-clr);
+        }
+
+        .modal.success h2 {
+            color: var(--success-clr);
+        }
+
+        .modal.error h2 {
+            color: var(--error-clr);
+        }
+
+        .modal p {
+            margin-top: 5px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="modal success">
+    <div class="body">
+        <div class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+                <polyline points="100 290 190 380 410 130"/>
+            </svg>
+        </div>
+        <h2>SUCCESS</h2>
+        <p>You have successfully logged into Vault!</p>
+    </div>
+</div>
+
+</body>
+</html>

--- a/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.core.plugin;
+
+import io.blt.gregbot.core.properties.Properties;
+import io.blt.gregbot.plugin.Plugin;
+import io.blt.gregbot.plugin.secrets.SecretPlugin;
+import io.blt.gregbot.plugin.secrets.vault.VaultOidc;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PluginLoaderTest {
+
+    interface InterfaceWithNoImplementations extends Plugin { }
+
+    @Test
+    void pluginsShouldReturnEmptyForInterfaceWithNoImplementations() {
+        var plugins = new PluginLoader<>(InterfaceWithNoImplementations.class)
+                .plugins();
+
+        assertThat(plugins)
+                .isEmpty();
+    }
+
+    @Nested
+    class SecretPluginInterface {
+
+        static Stream<Arguments> loadShouldReturnInstanceOfPluginType() {
+            return Stream.of(
+                    Arguments.of(
+                            "io.blt.gregbot.plugin.secrets.vault.VaultOidc",
+                            Map.of("host", "https://vault.cyberdyne.com"),
+                            VaultOidc.class));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        void loadShouldReturnInstanceOfPluginType(
+                String type, Map<String, String> properties, Class<? extends Plugin> expected) throws Exception {
+            var plugin = new PluginLoader<>(SecretPlugin.class)
+                    .load(new Properties.Plugin(type, properties));
+
+            assertThat(plugin)
+                    .isNotNull()
+                    .isInstanceOf(expected);
+        }
+
+        @Test
+        void pluginsShouldReturnListOfAllPluginTypes() {
+            var plugins = new PluginLoader<>(SecretPlugin.class)
+                    .plugins();
+
+            assertThat(plugins)
+                    .isNotEmpty()
+                    .containsExactlyInAnyOrder(
+                            "io.blt.gregbot.plugin.secrets.vault.VaultOidc"
+                    );
+        }
+    }
+
+}

--- a/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
@@ -8,17 +8,10 @@
 
 package io.blt.gregbot.core.plugin;
 
-import io.blt.gregbot.core.properties.Properties;
 import io.blt.gregbot.plugin.Plugin;
 import io.blt.gregbot.plugin.secrets.SecretPlugin;
-import io.blt.gregbot.plugin.secrets.vault.VaultOidc;
-import java.util.Map;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,26 +30,6 @@ class PluginLoaderTest {
 
     @Nested
     class SecretPluginInterface {
-
-        static Stream<Arguments> loadShouldReturnInstanceOfPluginType() {
-            return Stream.of(
-                    Arguments.of(
-                            "io.blt.gregbot.plugin.secrets.vault.VaultOidc",
-                            Map.of("host", "https://vault.cyberdyne.com"),
-                            VaultOidc.class));
-        }
-
-        @ParameterizedTest
-        @MethodSource
-        void loadShouldReturnInstanceOfPluginType(
-                String type, Map<String, String> properties, Class<? extends Plugin> expected) throws Exception {
-            var plugin = new PluginLoader<>(SecretPlugin.class)
-                    .load(new Properties.Plugin(type, properties));
-
-            assertThat(plugin)
-                    .isNotNull()
-                    .isInstanceOf(expected);
-        }
 
         @Test
         void pluginsShouldReturnListOfAllPluginTypes() {

--- a/src/test/java/io/blt/gregbot/plugin/connector/ConnectorTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/connector/ConnectorTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.connector;
+
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+@WireMockTest(proxyMode = true)
+class ConnectorTest {
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldThrowOnConstructionWhenHostIsNullOrEmpty(String host) {
+        assertThatException()
+                .isThrownBy(() -> new Connector(host))
+                .withMessage("'host' must not be empty");
+    }
+
+    @Test
+    void sendShouldReturnResponseAndEmptyDataForEndpointWithNoBody() throws IOException, InterruptedException {
+        mockEndpointReturning(ok());
+
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create("http://mock.domain/mock/path"))
+                .GET()
+                .build();
+
+        var result = new Connector("not-using-uri-builders")
+                .send(request);
+
+        assertThat(result.getResponse())
+                .extracting(HttpResponse::statusCode)
+                .isEqualTo(200);
+
+        assertThat(result.getData())
+                .isEmpty();
+    }
+
+    @Test
+    void sendShouldReturnResponseAndDataForEndpointWithJsonBody() throws IOException, InterruptedException {
+        mockEndpointReturning(okJson("{ \"name\": \"Greg\" }"));
+
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create("http://mock.domain/mock/path"))
+                .GET()
+                .build();
+
+        var result = new Connector("not-using-uri-builders")
+                .send(request, User.class);
+
+        assertThat(result.getResponse())
+                .extracting(HttpResponse::statusCode)
+                .isEqualTo(200);
+
+        assertThat(result.getData())
+                .containsInstanceOf(User.class)
+                .get()
+                .extracting(User::getName)
+                .isEqualTo("Greg");
+    }
+
+    @Test
+    void sendShouldReturnResponseAndEmptyDataForEndpointWithUnsupportedBody() throws IOException, InterruptedException {
+        mockEndpointReturning(ok("raw text"));
+
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create("http://mock.domain/mock/path"))
+                .GET()
+                .build();
+
+        var result = new Connector("not-using-uri-builders")
+                .send(request, User.class);
+
+        assertThat(result.getResponse())
+                .extracting(HttpResponse::statusCode)
+                .isEqualTo(200);
+
+        assertThat(result.getData())
+                .isEmpty();
+    }
+
+    @Test
+    void sendShouldResponseAndEmptyBodyForEndpointWithBadRequest() throws IOException, InterruptedException {
+        mockEndpointReturning(badRequest());
+
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create("http://mock.domain/mock/path"))
+                .GET()
+                .build();
+
+        var result = new Connector("not-using-uri-builders")
+                .send(request, null);
+
+        assertThat(result.getResponse())
+                .extracting(HttpResponse::statusCode)
+                .isEqualTo(400);
+
+        assertThat(result.getData())
+                .isEmpty();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "http://mock.domain,  /mock/path",
+            "http://mock.domain/, /mock/path",
+            "http://mock.domain,  mock/path",
+            "http://mock.domain/, mock/path"
+    })
+    void uriForPathShouldBuildUriFromConnectorHost(String host, String path) {
+        var result = new Connector(host)
+                .uriForPath(path);
+
+        assertThat(result)
+                .isEqualTo(URI.create("http://mock.domain/mock/path"));
+    }
+
+    @Test
+    void formFromMapShouldGenerateValidFormRequest() throws IOException, InterruptedException {
+        mockFormEndpoint(m -> m
+                .withFormParam("player1", equalTo("Greg"))
+                .withFormParam("player2", equalTo("Louis"))
+                .withFormParam("player3", equalTo("Phil"))
+        );
+
+        var form = Connector.formFromMap(Map.of(
+                "player1", "Greg",
+                "player2", "Louis",
+                "player3", "Phil"));
+
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create("http://mock.domain/mock/path"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(form)
+                .build();
+
+        var result = new Connector("not-using-uri-builders")
+                .send(request);
+
+        assertThat(result.getResponse())
+                .extracting(HttpResponse::statusCode)
+                .isEqualTo(200);
+    }
+
+    private void mockEndpointReturning(ResponseDefinitionBuilder responseDefinitionBuilder) {
+        stubFor(get("/mock/path")
+                .withHost(equalTo("mock.domain"))
+                .willReturn(responseDefinitionBuilder));
+    }
+
+    private void mockFormEndpoint(Consumer<MappingBuilder> mappingBuilderConsumer) {
+        var builder = post("/mock/path")
+                .withHost(equalTo("mock.domain"))
+                .willReturn(ok());
+
+        mappingBuilderConsumer.accept(builder);
+
+        stubFor(builder);
+    }
+
+    public static class User {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+
+}

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+
+class VaultOidcTest {
+
+    final Map<String, String> requiredProperties = Map.of(
+            "host", "mock-host"
+    );
+
+    @Test
+    void loadShouldNotThrowWhenPropertiesArePresent() {
+        assertThatNoException()
+                .isThrownBy(() -> new VaultOidc().load(requiredProperties));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "host"
+    })
+    void loadShouldThrowWhenPropertiesIsMissingKey(String key) {
+        var properties = requiredPropertiesWithout(key);
+        assertThatNullPointerException()
+                .isThrownBy(() -> new VaultOidc().load(properties));
+    }
+
+    private Map<String, String> requiredPropertiesWithout(String key) {
+        var properties = new HashMap<>(requiredProperties);
+        properties.remove(key);
+        return properties;
+    }
+
+}

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
@@ -8,26 +8,46 @@
 
 package io.blt.gregbot.plugin.secrets.vault;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.awt.*;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
+import org.assertj.core.api.SoftAssertionsProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 
+@WireMockTest(proxyMode = true)
+@ExtendWith(MockitoExtension.class)
 class VaultOidcTest {
 
-    final Map<String, String> requiredProperties = Map.of(
-            "host", "mock-host"
-    );
+    @Mock
+    Desktop desktop;
 
-    @Test
-    void loadShouldNotThrowWhenPropertiesArePresent() {
-        assertThatNoException()
-                .isThrownBy(() -> new VaultOidc().load(requiredProperties));
-    }
+    final Map<String, String> requiredProperties = Map.of(
+            "host", "http://mock-host"
+    );
 
     @ParameterizedTest
     @ValueSource(strings = {
@@ -35,14 +55,110 @@ class VaultOidcTest {
     })
     void loadShouldThrowWhenPropertiesIsMissingKey(String key) {
         var properties = requiredPropertiesWithout(key);
+
         assertThatNullPointerException()
                 .isThrownBy(() -> new VaultOidc().load(properties));
+    }
+
+    @Test
+    void loadShouldNotThrowWhenPropertiesArePresent() throws Exception {
+        mockVault();
+
+        doWithMockedDesktop(() -> new VaultOidc().load(requiredProperties));
+    }
+
+    @Test
+    void secretsForPathShouldReturnResultFromVault() throws Exception {
+        mockVault();
+
+        var plugin = new VaultOidc();
+        doWithMockedDesktop(() -> plugin.load(requiredProperties));
+
+        var result = plugin.secretsForPath("mock-secret-path");
+
+        assertThat(result)
+                .containsOnly(
+                        entry("mock-secret-key1", "mock-secret-value1"),
+                        entry("mock-secret-key2", "mock-secret-value2")
+                );
     }
 
     private Map<String, String> requiredPropertiesWithout(String key) {
         var properties = new HashMap<>(requiredProperties);
         properties.remove(key);
         return properties;
+    }
+
+    private void mockVault() {
+        stubFor(post("/v1/auth/oidc/oidc/auth_url")
+                .withHost(equalTo("mock-host"))
+                .willReturn(okJson("""
+                            {
+                              "data": {
+                                "auth_url": "http://localhost:8250/oidc/callback?state=mock-state&code=mock-code&id_token=mock-id-token"
+                              }
+                            }
+                            """)));
+
+
+        stubFor(get(urlMatching("/v1/auth/oidc/oidc/callback\\?state=mock-state&code=mock-code&id_token=mock-id-token&client_nonce=[\\w-]+"))
+                .withHost(equalTo("mock-host"))
+                .willReturn(okJson("""
+                            {
+                              "auth": {
+                                "client_token": "mock-token"
+                              }
+                            }
+                            """)));
+
+        stubFor(post("/v1/auth/token/renew-self")
+                .withHost(equalTo("mock-host"))
+                .willReturn(okJson("""
+                            {
+                              "auth": {
+                                "policies": [],
+                                "lease_duration": 3600
+                              },
+                              "renewable": true
+                            }
+                            """)));
+
+        stubFor(get("/v1/mock-secret-path")
+                .withHost(equalTo("mock-host"))
+                .willReturn(okJson("""
+                            {
+                              "data": {
+                                "mock-secret-key1": "mock-secret-value1",
+                                "mock-secret-key2": "mock-secret-value2"
+                              }
+                            }
+                            """)));
+    }
+
+    private void doWithMockedDesktop(SoftAssertionsProvider.ThrowingRunnable runnable) throws Exception {
+        mockDesktopBrowseToFetchUri();
+        try (var mock = Mockito.mockStatic(Desktop.class)) {
+            mock.when(Desktop::getDesktop).thenReturn(desktop);
+            runnable.run();
+        }
+    }
+
+    private void mockDesktopBrowseToFetchUri() throws IOException {
+        doAnswer(invocation -> {
+            URI uri = invocation.getArgument(0);
+            makeGetHttpCall(uri);
+            return null;
+        }).when(desktop).browse(any());
+    }
+
+    private void makeGetHttpCall(URI uri) throws IOException, InterruptedException {
+        var request = HttpRequest.newBuilder()
+                .uri(uri)
+                .GET()
+                .build();
+
+        HttpClient.newBuilder().build()
+                .send(request, HttpResponse.BodyHandlers.discarding());
     }
 
 }

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/connector/VaultConnectorTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/connector/VaultConnectorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.connector;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.AuthUrlRequest;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.AuthUrlResponse;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.CallbackRequest;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.CallbackResponse;
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WireMockTest(proxyMode = true)
+class VaultConnectorTest {
+
+    @Test
+    void fetchAuthUrlShouldPostAuthUrlRequestAndReturnAuthUrlResponse() throws IOException {
+        stubFor(post("/v1/auth/mock-mount/oidc/auth_url")
+                .withHost(equalTo("mock.vault"))
+                .withFormParam("role", equalTo("mock-role"))
+                .withFormParam("redirect_uri", equalTo("mock-redirect-url"))
+                .withFormParam("client_nonce", equalTo("mock-client-nonce"))
+                .willReturn(okJson("""
+                        {
+                          "request_id": "mock-request-id",
+                          "lease_id": "mock-lease-id",
+                          "renewable": false,
+                          "least_duration": 10,
+                          "data": {
+                            "auth_url": "mock-auth-url"
+                          }
+                        }
+                        """)));
+
+        var result = new VaultConnector("http://mock.vault")
+                .fetchAuthUrl(new AuthUrlRequest(
+                        "mock-mount",
+                        "mock-role",
+                        "mock-redirect-url",
+                        "mock-client-nonce"));
+
+        assertThat(result.getResponse())
+                .extracting(HttpResponse::statusCode)
+                .isEqualTo(200);
+
+        assertThat(result.getData())
+                .containsInstanceOf(AuthUrlResponse.class)
+                .get()
+                .extracting(
+                        AuthUrlResponse::requestId,
+                        AuthUrlResponse::leaseId,
+                        AuthUrlResponse::renewable,
+                        AuthUrlResponse::leastDuration,
+                        r -> r.data().authUrl())
+                .containsExactly(
+                        "mock-request-id",
+                        "mock-lease-id",
+                        false,
+                        10,
+                        "mock-auth-url");
+    }
+
+    @Test
+    void fetchCallbackShouldPostCallbackRequestAndReturnCallbackResponse() throws IOException {
+        stubFor(get("/v1/auth/mock-mount/oidc/callback" +
+                    "?state=mock-state" +
+                    "&code=mock-code" +
+                    "&id_token=mock-id-token" +
+                    "&client_nonce=mock-client-nonce")
+                .withHost(equalTo("mock.vault"))
+                .willReturn(okJson("""
+                        {
+                          "auth": {
+                            "client_token": "mock-client-token"
+                          }
+                        }
+                        """)));
+
+        var result = new VaultConnector("http://mock.vault")
+                .fetchCallback(new CallbackRequest(
+                        "mock-mount",
+                        "mock-state",
+                        "mock-code",
+                        "mock-id-token",
+                        "mock-client-nonce"));
+
+        assertThat(result.getResponse())
+                .extracting(HttpResponse::statusCode)
+                .isEqualTo(200);
+
+        assertThat(result.getData())
+                .containsInstanceOf(CallbackResponse.class)
+                .get()
+                .extracting(r -> r.auth().clientToken())
+                .isEqualTo("mock-client-token");
+    }
+
+}

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcHttpListenerTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcHttpListenerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.oidc;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+import static io.blt.gregbot.plugin.secrets.vault.oidc.OidcHttpListener.RequestConsumer.Request;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OidcHttpListenerTest {
+
+    @Test
+    void awaitShouldReturnFalseOnTimeout() throws IOException, InterruptedException {
+        var result = new OidcHttpListener("localhost", 8250, "/", r -> {})
+                .await(1);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void awaitShouldReturnTrueOnConnection() throws IOException, InterruptedException {
+        var listener = new OidcHttpListener("localhost", 8250, "/", r -> {});
+
+        makeHttpCall("http://localhost:8250/oidc/callback");
+
+        var result = listener.await(10);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void httpRequestShouldReceiveSuccessHtml() throws IOException, InterruptedException {
+        var listener = new OidcHttpListener("localhost", 8250, "/oidc/callback", r -> {});
+
+        var result = makeHttpCall("http://localhost:8250/oidc/callback");
+
+        listener.await(10);
+
+        assertThat(result.statusCode())
+                .isEqualTo(200);
+
+        assertThat(result.body())
+                .containsIgnoringCase("You have successfully logged into Vault");
+    }
+
+    @Test
+    void requestConsumerShouldConsumeRequestContainingUrlDetails() throws IOException, InterruptedException {
+        var request = new AtomicReference<Request>();
+
+        var listener = new OidcHttpListener("localhost", 8250, "/oidc/callback", request::set);
+        makeHttpCall("http://localhost:8250/oidc/callback?state=mock-state&code=mock-code&id_token=mock-id-token");
+        listener.await(10);
+
+        assertThat(request).hasValue(new Request("mock-state", "mock-code", "mock-id-token"));
+    }
+
+    private HttpResponse<String> makeHttpCall(String uri) {
+        var request = HttpRequest.newBuilder()
+                .uri(URI.create(uri))
+                .GET()
+                .build();
+
+        try {
+            return HttpClient.newBuilder().build()
+                    .send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.oidc;
+
+import io.blt.gregbot.plugin.connector.Connector;
+import io.blt.gregbot.plugin.secrets.vault.connector.VaultConnector;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.AuthUrlRequest;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.AuthUrlResponse;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.CallbackRequest;
+import io.blt.gregbot.plugin.secrets.vault.connector.dto.CallbackResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static io.blt.test.TestUtils.doIgnoreExceptions;
+import static io.blt.util.Obj.poke;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OidcTest {
+
+    @Mock
+    VaultConnector connector;
+
+    @Captor
+    ArgumentCaptor<AuthUrlRequest> authUrlRequestCaptor;
+
+    @Mock
+    Connector.Result<AuthUrlResponse> authUrlResponse;
+
+    @Captor
+    ArgumentCaptor<CallbackRequest> callbackRequestCaptor;
+
+    @Mock
+    Connector.Result<CallbackResponse> callbackResponse;
+
+    OidcConfig config = poke(new OidcConfig(), c -> c.setListenTimeout(1));
+
+    Oidc oidc;
+
+    @BeforeEach
+    void beforeEach() throws IOException {
+        this.oidc = new Oidc(config, connector);
+
+        when(authUrlResponse.getData())
+                .thenReturn(Optional.of(new AuthUrlResponse(
+                        null,
+                        null,
+                        false,
+                        0,
+                        new AuthUrlResponse.Data("http://localhost:8250/oidc/callback"),
+                        null,
+                        null,
+                        null
+                )));
+
+        when(connector.fetchAuthUrl(authUrlRequestCaptor.capture()))
+                .thenReturn(authUrlResponse);
+
+        lenient().when(callbackResponse.getData())
+                .thenReturn(Optional.of(new CallbackResponse(
+                        new CallbackResponse.Auth("mock-token")
+                )));
+
+        lenient().when(connector.fetchCallback(callbackRequestCaptor.capture()))
+                .thenReturn(callbackResponse);
+    }
+
+    @Test
+    void fetchAuthTokenShouldThrowTimeoutExceptionWhenCallbackNotCalled() {
+        assertThatExceptionOfType(TimeoutException.class)
+                .isThrownBy(() -> oidc.fetchAuthToken(uri -> {}))
+                .withMessage("Timeout of 1 seconds expired while waiting for callback");
+    }
+
+    @Test
+    void fetchAuthTokenShouldCallConnectorFetchAuthUrl() {
+        doIgnoreExceptions(() -> oidc.fetchAuthToken(uri -> {}));
+
+        assertThat(authUrlRequestCaptor.getAllValues())
+                .hasSize(1)
+                .first()
+                .extracting(AuthUrlRequest::mount, AuthUrlRequest::role, AuthUrlRequest::redirectUrl)
+                .containsExactly("oidc", "", "http://localhost:8250/oidc/callback");
+
+        assertThat(authUrlRequestCaptor.getValue().clientNonce())
+                .matches("^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}$");
+    }
+
+    @Test
+    void fetchAuthTokenShouldInvokeConsumerWithAuthUrl() {
+        var fetchAuthUri = new AtomicReference<URI>();
+
+        doIgnoreExceptions(() -> oidc.fetchAuthToken(fetchAuthUri::set));
+
+        assertThat(fetchAuthUri.get())
+                .isEqualTo(URI.create("http://localhost:8250/oidc/callback"));
+    }
+
+    @Test
+    void fetchAuthTokenShouldReturnTokenWhenCallingAuthUrl()
+            throws IOException, InterruptedException, TimeoutException {
+        var result = oidc.fetchAuthToken(this::makeHttpCall);
+
+        assertThat(result)
+                .isEqualTo("mock-token");
+    }
+
+    private void makeHttpCall(URI uri) {
+        var request = HttpRequest.newBuilder()
+                .uri(uri)
+                .GET()
+                .build();
+
+        try {
+            HttpClient.newBuilder().build()
+                    .send(request, HttpResponse.BodyHandlers.discarding());
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/io/blt/test/TestUtils.java
+++ b/src/test/java/io/blt/test/TestUtils.java
@@ -11,12 +11,19 @@ package io.blt.test;
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 
 public final class TestUtils {
 
     private TestUtils() {
         throw new IllegalAccessError("Utility class should be accessed statically and never constructed");
+    }
+
+    public static <T> void doIgnoreExceptions(Callable<T> callable) {
+        try {
+            callable.call();
+        } catch (Exception ignored) { }
     }
 
     public static <T> Stream<Field> streamFieldsOfNestedTypes(Class<T> type) {


### PR DESCRIPTION
### Add `SecretPlugin` interface and `VaultOidc` implementation

Adds a basic `PluginLoader`, `SecretPlugin` interface and (primarily) a `VaultOidc` implementation.

`VaultOidc` works in a very similar way to [Hashicorp's own command line tool](https://developer.hashicorp.com/vault/tutorials/auth-methods/oidc-auth#login-with-oidc) and involves using a local web browser to open a Vault URL with a callback pointing to a `localhost` server.

This is particularly convenient for a desktop user and it means the plugin requires no keys or secrets of its own _at all_.
All that is required is the Vault host and the secret path.

The intention is to reuse the plugin work to support Identities.