### PR TITLE
Add engine version support to VaultOidc

### DIFF
--- a/src/main/java/io/blt/gregbot/plugin/secrets/SecretException.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/SecretException.java
@@ -8,11 +8,10 @@
 
 package io.blt.gregbot.plugin.secrets;
 
-import io.blt.gregbot.plugin.Plugin;
-import java.util.Map;
+public class SecretException extends Exception {
 
-public interface SecretPlugin extends Plugin {
-
-    Map<String, String> secretsForPath(String path) throws SecretException;
+    public SecretException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
 }

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
@@ -29,6 +29,7 @@ public class VaultOidc implements SecretPlugin {
     public void load(Map<String, String> properties)
             throws IOException, InterruptedException, VaultException, TimeoutException {
         var host = Objects.requireNonNull(properties.get("host"), "must specify 'host' property");
+        var engineVersion = Integer.valueOf(properties.getOrDefault("engine", "2"));
 
         var connector = new VaultConnector(host);
 
@@ -37,7 +38,7 @@ public class VaultOidc implements SecretPlugin {
 
         vault = new Vault(new VaultConfig()
                 .address(host)
-                .engineVersion(1)
+                .engineVersion(engineVersion)
                 .token(token)
                 .build());
 

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
@@ -11,6 +11,7 @@ package io.blt.gregbot.plugin.secrets.vault;
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
+import io.blt.gregbot.plugin.secrets.SecretException;
 import io.blt.gregbot.plugin.secrets.SecretPlugin;
 import io.blt.gregbot.plugin.secrets.vault.connector.VaultConnector;
 import io.blt.gregbot.plugin.secrets.vault.oidc.Oidc;
@@ -45,13 +46,13 @@ public class VaultOidc implements SecretPlugin {
     }
 
     @Override
-    public Map<String, String> secretsForPath(String path) {
+    public Map<String, String> secretsForPath(String path) throws SecretException {
         try {
             return vault.logical()
                     .read(path)
                     .getData();
         } catch (VaultException e) {
-            throw new RuntimeException(e);
+            throw new SecretException("Failed to fetch a secret for path: " + path, e);
         }
     }
 }


### PR DESCRIPTION
### Add engine version support to `VaultOidc`

Follows on from https://github.com/michaelcowan/gregbot/pull/13 by adding support for [Vault KV secrets engine](https://developer.hashicorp.com/vault/docs/secrets/kv) versions (currently 1 or 2).

By default the plugin will use version 2 (same as the Vault SDK).
A specific version can be specified by adding an `engine` value to `properties` e.g.
```json
"secrets": {
  "Cyberdyne Vault": {
    "plugin": {
      "type": "io.blt.gregbot.plugin.VaultOidc",
      "properties": {
        "host": "https://vault.cyberdyne.com",
        "engine": "1"
      }
    }
  }
},
```

I also took the opportunity to add checked exception `SecretException` to the `secretsForPath` signature.