### PR TITLE
Configure VaultOidc from properties

### DIFF
--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
@@ -33,7 +33,7 @@ public class VaultOidc implements SecretPlugin {
         var connector = new VaultConnector(host);
 
         try {
-            var token = new Oidc(new OidcConfig(), connector)
+            var token = new Oidc(OidcConfig.from(properties), connector)
                     .fetchAuthTokenUsingDesktopBrowse();
 
             vault = new Vault(new VaultConfig()

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/oidc/Oidc.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/oidc/Oidc.java
@@ -50,8 +50,8 @@ public class Oidc {
     private String fetchAuthURL(String nonce) throws IOException {
         var result = connector.fetchAuthUrl(
                 new AuthUrlRequest(
-                        config.getMount(),
-                        config.getRole(),
+                        config.mount(),
+                        config.role(),
                         buildRedirectUrl(),
                         nonce));
 
@@ -63,10 +63,10 @@ public class Oidc {
 
     private String buildRedirectUrl() {
         return new URIBuilder()
-                .setScheme(config.getCallbackScheme())
-                .setHost(config.getCallbackHost())
-                .setPort(config.getCallbackPort())
-                .setPath(config.getCallbackPath())
+                .setScheme(config.callbackScheme())
+                .setHost(config.callbackHost())
+                .setPort(config.callbackPort())
+                .setPath(config.callbackPath())
                 .toString();
     }
 
@@ -75,11 +75,11 @@ public class Oidc {
         var token = new AtomicReference<String>();
 
         var listener = new OidcHttpListener(
-                config.getListenHost(),
-                config.getListenPort(),
-                config.getListenPath(), request -> {
+                config.listenHost(),
+                config.listenPort(),
+                config.listenPath(), request -> {
             var result = connector.fetchCallback(new CallbackRequest(
-                    config.getMount(),
+                    config.mount(),
                     request.state(),
                     request.code(),
                     request.idToken(),
@@ -94,9 +94,9 @@ public class Oidc {
 
         fetchAuth.accept(URI.create(authUrl));
 
-        if (!listener.await(config.getListenTimeout())) {
+        if (!listener.await(config.listenTimeout())) {
             throw new TimeoutException(
-                    "Timeout of " + config.getListenTimeout() + " seconds expired while waiting for callback");
+                    "Timeout of " + config.listenTimeout() + " seconds expired while waiting for callback");
         }
 
         return token.get();

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcConfig.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcConfig.java
@@ -8,95 +8,64 @@
 
 package io.blt.gregbot.plugin.secrets.vault.oidc;
 
-public class OidcConfig {
-    private String role = "";
-    private String mount = "oidc";
-    private String listenHost = "localhost";
-    private int listenPort = 8250;
-    private String listenPath = "/" + mount + "/callback";
-    private int listenTimeout = 10;
-    private String callbackScheme = "http";
-    private String callbackHost = listenHost;
-    private int callbackPort = listenPort;
-    private String callbackPath = listenPath;
+import java.util.HashMap;
+import java.util.Map;
 
-    public String getRole() {
-        return role;
-    }
+import static io.blt.gregbot.plugin.utils.PluginUtils.propertiesToType;
 
-    public void setRole(String role) {
-        this.role = role;
-    }
+public record OidcConfig(
+        String role,
+        String mount,
+        String listenHost,
+        int listenPort,
+        String listenPath,
+        int listenTimeout,
+        String callbackScheme,
+        String callbackHost,
+        int callbackPort,
+        String callbackPath) {
 
-    public String getMount() {
-        return mount;
-    }
+    /**
+     * Creates an instance of {@link OidcConfig} by copying values from the passed {@code properties}.
+     * If a value is not present in {@code properties} then a default is used.
+     * <p>
+     *     Supported properties and their default values:
+     *     <ul>
+     *         <li>{@code role} - {@code ""}</li>
+     *         <li>{@code mount} - {@code "oidc"}</li>
+     *         <li>{@code listenHost} - {@code "localhost"}</li>
+     *         <li>{@code listenPort} - {@code "8250"}</li>
+     *         <li>{@code listenPath} - '/{mount}/callback' e.g. {@code "/oidc/callback"}</li>
+     *         <li>{@code listenTimeout} - {@code "10"}</li>
+     *         <li>{@code callbackScheme} - {@code "http"}</li>
+     *         <li>{@code callbackHost} - same as {@code listenHost}</li>
+     *         <li>{@code callbackPort} - same as {@code listenPort}</li>
+     *         <li>{@code callbackPath} - same as {@code listenPath}</li>
+     *     </ul>
+     * </p>
+     * <p>
+     *     These values are equivalent to the Vault CLI OIDC login options
+     *     {@see <a href="https://developer.hashicorp.com/vault/docs/auth/jwt#oidc-login-cli">Vault OIDC Login CLI</a>}
+     * </p>
+     *
+     * @param properties {@link Map} that may contain configuration values
+     * @return an instance of {@link OidcConfig} constructed from defaults and passed {@code properties}
+     * @throws NullPointerException if properties is null.
+     */
+    public static OidcConfig from(Map<String, String> properties) {
+        var config = new HashMap<>(properties);
 
-    public void setMount(String mount) {
-        this.mount = mount;
-    }
+        config.putIfAbsent("role", "");
+        config.putIfAbsent("mount", "oidc");
+        config.putIfAbsent("listenHost", "localhost");
+        config.putIfAbsent("listenPort", "8250");
+        config.putIfAbsent("listenPath", "/" + config.get("mount") + "/callback");
+        config.putIfAbsent("listenTimeout", "10");
+        config.putIfAbsent("callbackScheme", "http");
+        config.putIfAbsent("callbackHost", config.get("listenHost"));
+        config.putIfAbsent("callbackPort", config.get("listenPort"));
+        config.putIfAbsent("callbackPath", config.get("listenPath"));
 
-    public String getListenHost() {
-        return listenHost;
-    }
-
-    public void setListenHost(String listenHost) {
-        this.listenHost = listenHost;
-    }
-
-    public int getListenPort() {
-        return listenPort;
-    }
-
-    public void setListenPort(int listenPort) {
-        this.listenPort = listenPort;
-    }
-
-    public String getListenPath() {
-        return listenPath;
-    }
-
-    public void setListenPath(String listenPath) {
-        this.listenPath = listenPath;
-    }
-
-    public int getListenTimeout() {
-        return listenTimeout;
-    }
-
-    public void setListenTimeout(int listenTimeout) {
-        this.listenTimeout = listenTimeout;
-    }
-
-    public String getCallbackScheme() {
-        return callbackScheme;
-    }
-
-    public void setCallbackScheme(String callbackScheme) {
-        this.callbackScheme = callbackScheme;
-    }
-
-    public int getCallbackPort() {
-        return callbackPort;
-    }
-
-    public void setCallbackPort(int callbackPort) {
-        this.callbackPort = callbackPort;
-    }
-
-    public String getCallbackHost() {
-        return callbackHost;
-    }
-
-    public void setCallbackHost(String callbackHost) {
-        this.callbackHost = callbackHost;
-    }
-
-    public String getCallbackPath() {
-        return callbackPath;
-    }
-
-    public void setCallbackPath(String callbackPath) {
-        this.callbackPath = callbackPath;
+        return propertiesToType(OidcConfig.class, config);
     }
 }

--- a/src/main/java/io/blt/gregbot/plugin/utils/PluginUtils.java
+++ b/src/main/java/io/blt/gregbot/plugin/utils/PluginUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.utils;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import java.util.Map;
+
+public class PluginUtils {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE);
+
+    private PluginUtils() {
+        throw new IllegalAccessError("Utility class should be accessed statically and never constructed");
+    }
+
+    /**
+     * Returns an instance of {@code type} constructed from values in {@code properties}.
+     * <p>
+     *     If {@code properties} is missing a member of {@code type}, the value will default e.g. {@code null} or {@code 0}.
+     *     If {@code properties} contains a key that does not match a member, the value will be ignored.
+     * </p>
+     *
+     * @param type the target type to instantiate
+     * @param properties {@link Map} containing values for the members of {@code type}
+     * @return instance of {@code T}
+     * @param <T> type variable for {@code type}.
+     */
+    public static <T> T propertiesToType(Class<T> type, Map<String, String> properties) {
+        return MAPPER.convertValue(properties, type);
+    }
+
+}

--- a/src/test/java/io/blt/gregbot/plugin/PluginUtilsTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/PluginUtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static io.blt.gregbot.plugin.utils.PluginUtils.propertiesToType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PluginUtilsTest {
+
+    private record TestType(String name, int age, String favouriteFood) {}
+
+    @Test
+    void propertiesToTypeShouldCreateAnInstanceOfTheTargetTypeFromPassedProperties() {
+        var result = propertiesToType(TestType.class, Map.of(
+                "name", "Mike",
+                "age", "80",
+                "favouriteFood", "pizza"));
+
+        assertThat(result)
+                .isInstanceOf(TestType.class)
+                .extracting(TestType::name, TestType::age, TestType::favouriteFood)
+                .containsExactly("Mike", 80, "pizza");
+    }
+
+    @Test
+    void propertiesToTypeShouldDefaultMissingValuesToNull() {
+        var result = propertiesToType(TestType.class, Map.of(
+                "name", "Mike"));
+
+        assertThat(result)
+                .isInstanceOf(TestType.class)
+                .extracting(TestType::name, TestType::age, TestType::favouriteFood)
+                .containsExactly("Mike", 0, null);
+    }
+
+    @Test
+    void propertiesToTypeShouldIgnoreUnknownKeys() {
+        var result = propertiesToType(TestType.class, Map.of(
+                "name", "Mike",
+                "height", "extra medium",
+                "age", "80",
+                "favouriteFood", "pizza"));
+
+        assertThat(result)
+                .isInstanceOf(TestType.class)
+                .extracting(TestType::name, TestType::age, TestType::favouriteFood)
+                .containsExactly("Mike", 80, "pizza");
+    }
+
+}

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
@@ -9,6 +9,7 @@
 package io.blt.gregbot.plugin.secrets.vault;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.blt.gregbot.plugin.secrets.SecretException;
 import java.awt.*;
 import java.io.IOException;
 import java.net.URI;
@@ -35,6 +36,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
@@ -79,6 +81,17 @@ class VaultOidcTest {
         assertThatException()
                 .isThrownBy(() -> new VaultOidc().load(properties))
                 .withMessageContaining(value);
+    }
+
+    @Test
+    void loadShouldUsePropertiesWhenConfiguringOidc() {
+        mockVault();
+
+        var properties = requiredPropertiesWith("listenPort", "8251");
+
+        assertThatExceptionOfType(SecretException.class)
+                .isThrownBy(() -> doWithMockedDesktop(() -> new VaultOidc().load(properties)))
+                .withMessageContaining("Failed to load using properties: {host=http://mock-host, listenPort=8251}");
     }
 
     @Test

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcConfigTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcConfigTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.secrets.vault.oidc;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class OidcConfigTest {
+
+    @Test
+    void fromShouldThrowNullPointerExceptionWhenPropertiesIsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> OidcConfig.from(null));
+    }
+
+    @Test
+    void fromShouldUsePassedProperties() {
+        var result = OidcConfig.from(Map.of(
+                "role", "mock-role",
+                "mount", "mock-mount",
+                "listenHost", "mock-listen-host",
+                "listenPort", "1",
+                "listenPath", "mock-listen-path",
+                "listenTimeout", "2",
+                "callbackScheme", "mock-callback-scheme",
+                "callbackHost", "mock-callback-host",
+                "callbackPort", "3",
+                "callbackPath", "mock-callback-path"));
+
+        assertThat(result)
+                .isEqualTo(new OidcConfig(
+                        "mock-role",
+                        "mock-mount",
+                        "mock-listen-host",
+                        1,
+                        "mock-listen-path",
+                        2,
+                        "mock-callback-scheme",
+                        "mock-callback-host",
+                        3,
+                        "mock-callback-path"));
+    }
+
+    @Test
+    void fromShouldUseDefaultValuesWhenNoPropertiesArePassed() {
+        var result = OidcConfig.from(Map.of());
+
+        assertThat(result)
+                .isEqualTo(new OidcConfig(
+                        "",
+                        "oidc",
+                        "localhost",
+                        8250,
+                        "/oidc/callback",
+                        10,
+                        "http",
+                        "localhost",
+                        8250,
+                        "/oidc/callback"));
+    }
+
+    @Test
+    void fromShouldIgnoreUnknownProperties() {
+        var result = OidcConfig.from(Map.of("unknown-key", "unknown-value"));
+
+        assertThat(result)
+                .isEqualTo(new OidcConfig(
+                        "",
+                        "oidc",
+                        "localhost",
+                        8250,
+                        "/oidc/callback",
+                        10,
+                        "http",
+                        "localhost",
+                        8250,
+                        "/oidc/callback"));
+    }
+
+    @Test
+    void fromShouldDefaultCallbackPropertiesToSameValueAsListenProperties() {
+        var result = OidcConfig.from(Map.of(
+                "listenHost", "mock-listen-host",
+                "listenPort", "1234",
+                "listenPath", "mock-listen-path"));
+
+        assertThat(result)
+                .extracting(
+                        OidcConfig::callbackHost,
+                        OidcConfig::callbackPort,
+                        OidcConfig::callbackPath)
+                .containsExactly(
+                        "mock-listen-host",
+                        1234,
+                        "mock-listen-path");
+    }
+
+    @Test
+    void fromShouldDefaultListenPathUsingMountVault() {
+        var result = OidcConfig.from(Map.of("mount", "mock-mount"));
+
+        assertThat(result)
+                .extracting(OidcConfig::listenPath)
+                .isEqualTo("/mock-mount/callback");
+    }
+
+}

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/oidc/OidcTest.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -31,7 +32,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static io.blt.test.TestUtils.doIgnoreExceptions;
-import static io.blt.util.Obj.poke;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.lenient;
@@ -55,7 +55,7 @@ class OidcTest {
     @Mock
     Connector.Result<CallbackResponse> callbackResponse;
 
-    OidcConfig config = poke(new OidcConfig(), c -> c.setListenTimeout(1));
+    OidcConfig config = OidcConfig.from(Map.of("listenTimeout", "1"));
 
     Oidc oidc;
 


### PR DESCRIPTION
### Configure `VaultOidc` from properties

The Vault CLI provides [several options when using the OIDC login method](https://developer.hashicorp.com/vault/docs/auth/jwt#oidc-login-cl). 

This change adds similar options that can be driven from plugin properties.

Default values have not changed.
