### PR TITLE
Add requiredProperties to Plugin interface

### DIFF
--- a/src/main/java/io/blt/gregbot/plugin/Plugin.java
+++ b/src/main/java/io/blt/gregbot/plugin/Plugin.java
@@ -10,8 +10,11 @@ package io.blt.gregbot.plugin;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
+import java.util.Set;
 
 public interface Plugin {
+
+    Set<String> requiredProperties();
 
     void load(@NotNull Map<String, String> properties) throws PluginException;
 

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
@@ -19,11 +19,17 @@ import io.blt.gregbot.plugin.secrets.vault.oidc.OidcConfig;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
 public class VaultOidc implements SecretPlugin {
 
     private Vault vault;
+
+    @Override
+    public Set<String> requiredProperties() {
+        return Set.of("host");
+    }
 
     @Override
     public void load(Map<String, String> properties) throws SecretException {

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
@@ -18,12 +18,13 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertionsProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -53,10 +54,18 @@ class VaultOidcTest {
             "host", "http://mock-host"
     );
 
+    @Test
+    void requiredPropertiesShouldReturnSetOfRequiredKeys() {
+        assertThat(new VaultOidc().requiredProperties())
+                .containsExactlyInAnyOrder("host");
+    }
+
+    static Stream<String> loadShouldThrowWhenPropertiesIsMissingKey() {
+        return new VaultOidc().requiredProperties().stream();
+    }
+
     @ParameterizedTest
-    @ValueSource(strings = {
-            "host"
-    })
+    @MethodSource
     void loadShouldThrowWhenPropertiesIsMissingKey(String key) {
         var properties = requiredPropertiesWithout(key);
 


### PR DESCRIPTION
### Add `requiredProperties` to `Plugin` interface

Allows a plugin to specify which properties must be present in order for `load` to pass basic `null` checks.

This could be used to prompt a user for keys not present in loaded properties (from JSON file).