### PR TITLE
Add IdentityService

### DIFF
--- a/src/main/java/io/blt/gregbot/core/plugin/PluginLoader.java
+++ b/src/main/java/io/blt/gregbot/core/plugin/PluginLoader.java
@@ -14,10 +14,14 @@ import io.blt.gregbot.plugin.PluginContext;
 import io.blt.gregbot.plugin.PluginException;
 import io.blt.util.Obj;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.ServiceLoader;
 
 import static io.blt.util.stream.SingletonCollectors.toOptional;
 
+/**
+ * A facility to load implementations of {@code Plugin}.
+ */
 public class PluginLoader<T extends Plugin> {
 
     private final List<T> plugins;
@@ -28,14 +32,36 @@ public class PluginLoader<T extends Plugin> {
                 .toList();
     }
 
+    /**
+     * Loads an implementation of {@code Plugin} matching the provided plugin properties.
+     *
+     * @param plugin the plugin properties
+     * @return loaded plugin instance
+     * @throws PluginException        if there is an error loading the plugin
+     * @throws NoSuchElementException if no plugin matches the properties
+     */
     public T load(Properties.Plugin plugin) throws PluginException {
         return load(new PluginContext(), plugin);
     }
 
+    /**
+     * Loads an implementation of {@code Plugin} matching the provided plugin properties.
+     *
+     * @param context the plugin context
+     * @param plugin  the plugin properties
+     * @return loaded plugin instance
+     * @throws PluginException        if there is an error loading the plugin
+     * @throws NoSuchElementException if no plugin matches the properties
+     */
     public T load(PluginContext context, Properties.Plugin plugin) throws PluginException {
         return Obj.poke(findPluginOrThrow(plugin), p -> p.load(context, plugin.properties()));
     }
 
+    /**
+     * Returns a list of all plugin types loaded by {@code PluginLoader}.
+     *
+     * @return list of plugin types
+     */
     public List<String> plugins() {
         return plugins.stream()
                 .map(this::pluginType)

--- a/src/main/java/io/blt/gregbot/core/plugin/PluginLoader.java
+++ b/src/main/java/io/blt/gregbot/core/plugin/PluginLoader.java
@@ -10,6 +10,7 @@ package io.blt.gregbot.core.plugin;
 
 import io.blt.gregbot.core.properties.Properties;
 import io.blt.gregbot.plugin.Plugin;
+import io.blt.gregbot.plugin.PluginContext;
 import io.blt.gregbot.plugin.PluginException;
 import io.blt.util.Obj;
 import java.util.List;
@@ -28,7 +29,11 @@ public class PluginLoader<T extends Plugin> {
     }
 
     public T load(Properties.Plugin plugin) throws PluginException {
-        return Obj.poke(findPluginOrThrow(plugin), p -> p.load(plugin.properties()));
+        return load(new PluginContext(), plugin);
+    }
+
+    public T load(PluginContext context, Properties.Plugin plugin) throws PluginException {
+        return Obj.poke(findPluginOrThrow(plugin), p -> p.load(context, plugin.properties()));
     }
 
     public List<String> plugins() {

--- a/src/main/java/io/blt/gregbot/core/services/IdentityService.java
+++ b/src/main/java/io/blt/gregbot/core/services/IdentityService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.core.services;
+
+import io.blt.gregbot.core.plugin.PluginLoader;
+import io.blt.gregbot.core.properties.Properties.Identity;
+import io.blt.gregbot.core.properties.Properties.Secret;
+import io.blt.gregbot.plugin.PluginContext;
+import io.blt.gregbot.plugin.PluginException;
+import io.blt.gregbot.plugin.identities.IdentityPlugin;
+import io.blt.gregbot.plugin.secrets.SecretPlugin;
+import io.blt.util.Ctr;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+/**
+ * Manages the loading of identity plugins and any secret plugin dependencies.
+ */
+public class IdentityService {
+
+    private final Map<String, SecretPlugin> secretPlugins;
+    private final Map<String, IdentityPlugin> identityPlugins;
+
+    public IdentityService(
+            Map<String, Secret> secrets,
+            Map<String, Identity> identities) throws PluginException {
+        this.secretPlugins = loadSecretPlugins(secrets);
+        this.identityPlugins = loadIdentityPlugins(identities);
+    }
+
+    /**
+     * Finds a fully loaded {@link IdentityPlugin} instance based on the provided identity name.
+     *
+     * @param identity the identity name to search for
+     * @return the found {@link IdentityPlugin} or empty if not found
+     */
+    public Optional<IdentityPlugin> find(String identity) {
+        return Optional.ofNullable(identityPlugins.get(identity));
+    }
+
+    private Map<String, SecretPlugin> loadSecretPlugins(Map<String, Secret> secrets) throws PluginException {
+        var loader = new PluginLoader<>(SecretPlugin.class);
+        return Ctr.transformValues(secrets, s -> loader.load(s.plugin()));
+    }
+
+    private Map<String, IdentityPlugin> loadIdentityPlugins(Map<String, Identity> identities) throws PluginException {
+        var loader = new PluginLoader<>(IdentityPlugin.class);
+        return Ctr.transformValues(identities, i -> {
+            var secretPlugin = nonNull(i.secrets()) ? findSecretPlugin(i.secrets()) : null;
+            return loader.load(new PluginContext(secretPlugin), i.plugin());
+        });
+    }
+
+    private SecretPlugin findSecretPlugin(String name) {
+        var result = secretPlugins.get(name);
+        if (isNull(result)) {
+            throw new IllegalArgumentException("Cannot find secret plugin " + name);
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/PluginContext.java
+++ b/src/main/java/io/blt/gregbot/plugin/PluginContext.java
@@ -8,14 +8,4 @@
 
 package io.blt.gregbot.plugin;
 
-import jakarta.validation.constraints.NotNull;
-import java.util.Map;
-import java.util.Set;
-
-public interface Plugin {
-
-    Set<String> requiredProperties();
-
-    void load(@NotNull PluginContext context, @NotNull Map<String, String> properties) throws PluginException;
-
-}
+public record PluginContext() { }

--- a/src/main/java/io/blt/gregbot/plugin/PluginContext.java
+++ b/src/main/java/io/blt/gregbot/plugin/PluginContext.java
@@ -8,4 +8,13 @@
 
 package io.blt.gregbot.plugin;
 
-public record PluginContext() { }
+import io.blt.gregbot.plugin.secrets.SecretPlugin;
+
+public record PluginContext(
+        SecretPlugin secretPlugin) {
+
+    public PluginContext() {
+        this(null);
+    }
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/identities/IdentityException.java
+++ b/src/main/java/io/blt/gregbot/plugin/identities/IdentityException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.identities;
+
+import io.blt.gregbot.plugin.PluginException;
+
+public class IdentityException extends PluginException {
+
+    public IdentityException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/identities/IdentityPlugin.java
+++ b/src/main/java/io/blt/gregbot/plugin/identities/IdentityPlugin.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.identities;
+
+import io.blt.gregbot.plugin.Plugin;
+import java.util.Map;
+
+public interface IdentityPlugin extends Plugin {
+
+    Map<String, String> variables() throws IdentityException;
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
@@ -11,6 +11,7 @@ package io.blt.gregbot.plugin.secrets.vault;
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
+import io.blt.gregbot.plugin.PluginContext;
 import io.blt.gregbot.plugin.secrets.SecretException;
 import io.blt.gregbot.plugin.secrets.SecretPlugin;
 import io.blt.gregbot.plugin.secrets.vault.connector.VaultConnector;
@@ -32,7 +33,7 @@ public class VaultOidc implements SecretPlugin {
     }
 
     @Override
-    public void load(Map<String, String> properties) throws SecretException {
+    public void load(PluginContext context, Map<String, String> properties) throws SecretException {
         var host = Objects.requireNonNull(properties.get("host"), "must specify 'host' property");
         var engineVersion = Integer.valueOf(properties.getOrDefault("engine", "2"));
 

--- a/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
@@ -12,6 +12,7 @@ import io.blt.gregbot.core.properties.Properties;
 import io.blt.gregbot.plugin.Plugin;
 import io.blt.gregbot.plugin.PluginContext;
 import io.blt.gregbot.plugin.PluginException;
+import io.blt.gregbot.plugin.identities.IdentityPlugin;
 import io.blt.gregbot.plugin.secrets.SecretPlugin;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
@@ -72,6 +73,56 @@ class PluginLoaderTest {
             var plugin = new Properties.Plugin(TestableSecretPlugin.TYPE, properties);
 
             var result = ((TestableSecretPlugin) loader.load(context, plugin));
+
+            assertThat(result.loadedProperties())
+                    .containsExactlyEntriesOf(properties);
+            assertThat(result.loadedContext())
+                    .isSameAs(context);
+        }
+    }
+
+    @Nested
+    class IdentityPluginInterface {
+
+        PluginLoader<?> loader = new PluginLoader<>(IdentityPlugin.class);
+        PluginContext context = new PluginContext();
+
+        @Test
+        void pluginsShouldReturnListOfAllPluginTypes() {
+            var plugins = loader.plugins();
+
+            assertThat(plugins)
+                    .isNotEmpty()
+                    .contains(TestableIdentityPlugin.TYPE);
+        }
+
+        @Test
+        void loadShouldReturnInstanceOfIdentityPlugin() throws PluginException {
+            var plugin = new Properties.Plugin(TestableIdentityPlugin.TYPE, Map.of());
+
+            var result = loader.load(context, plugin);
+
+            assertThat(result)
+                    .isInstanceOf(IdentityPlugin.class);
+        }
+
+        @Test
+        void loadShouldCallIdentityPluginLoadPassingProperties() throws PluginException {
+            var properties = Map.of("mock-key", "mock-value");
+            var plugin = new Properties.Plugin(TestableIdentityPlugin.TYPE, properties);
+
+            var result = ((TestableIdentityPlugin) loader.load(context, plugin));
+
+            assertThat(result.loadedProperties())
+                    .containsExactlyEntriesOf(properties);
+        }
+
+        @Test
+        void loadShouldCallIdentityPluginLoadPassingContext() throws PluginException {
+            var properties = Map.of("mock-key", "mock-value");
+            var plugin = new Properties.Plugin(TestableIdentityPlugin.TYPE, properties);
+
+            var result = ((TestableIdentityPlugin) loader.load(context, plugin));
 
             assertThat(result.loadedProperties())
                     .containsExactlyEntriesOf(properties);

--- a/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
@@ -104,7 +104,7 @@ class PluginLoaderTest {
     class IdentityPluginInterface {
 
         PluginLoader<?> loader = new PluginLoader<>(IdentityPlugin.class);
-        PluginContext context = new PluginContext();
+        PluginContext context = new PluginContext(new TestableSecretPlugin());
 
         @Test
         void pluginsShouldReturnListOfAllPluginTypes() {

--- a/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
@@ -15,10 +15,12 @@ import io.blt.gregbot.plugin.PluginException;
 import io.blt.gregbot.plugin.identities.IdentityPlugin;
 import io.blt.gregbot.plugin.secrets.SecretPlugin;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class PluginLoaderTest {
 
@@ -79,6 +81,23 @@ class PluginLoaderTest {
             assertThat(result.loadedContext())
                     .isSameAs(context);
         }
+
+        @Test
+        void loadShouldThrowWhenPluginTypeCannotBeFound() {
+            var plugin = new Properties.Plugin("UnknownType", Map.of());
+
+            assertThatExceptionOfType(NoSuchElementException.class)
+                    .isThrownBy(() -> loader.load(plugin));
+        }
+
+        @Test
+        void loadShouldThrowWhenPluginLoadThrows() {
+            var plugin = new Properties.Plugin(ThrowOnLoadSecretPlugin.TYPE, Map.of());
+
+            assertThatExceptionOfType(PluginException.class)
+                    .isThrownBy(() -> loader.load(plugin))
+                    .withMessage("secret plugin test load exception");
+        }
     }
 
     @Nested
@@ -128,6 +147,23 @@ class PluginLoaderTest {
                     .containsExactlyEntriesOf(properties);
             assertThat(result.loadedContext())
                     .isSameAs(context);
+        }
+
+        @Test
+        void loadShouldThrowWhenPluginTypeCannotBeFound() {
+            var plugin = new Properties.Plugin("UnknownType", Map.of());
+
+            assertThatExceptionOfType(NoSuchElementException.class)
+                    .isThrownBy(() -> loader.load(plugin));
+        }
+
+        @Test
+        void loadShouldThrowWhenPluginLoadThrows() {
+            var plugin = new Properties.Plugin(ThrowOnLoadIdentityPlugin.TYPE, Map.of());
+
+            assertThatExceptionOfType(PluginException.class)
+                    .isThrownBy(() -> loader.load(plugin))
+                    .withMessage("identity plugin test load exception");
         }
     }
 

--- a/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
@@ -10,6 +10,7 @@ package io.blt.gregbot.core.plugin;
 
 import io.blt.gregbot.core.properties.Properties;
 import io.blt.gregbot.plugin.Plugin;
+import io.blt.gregbot.plugin.PluginContext;
 import io.blt.gregbot.plugin.PluginException;
 import io.blt.gregbot.plugin.secrets.SecretPlugin;
 import java.util.Map;
@@ -58,11 +59,24 @@ class PluginLoaderTest {
             var properties = Map.of("mock-key", "mock-value");
             var plugin = new Properties.Plugin(TestableSecretPlugin.TYPE, properties);
 
-            var loadedProperties = ((TestableSecretPlugin) loader.load(plugin))
-                    .loadedProperties();
+            var result = ((TestableSecretPlugin) loader.load(plugin));
 
-            assertThat(loadedProperties)
+            assertThat(result.loadedProperties())
                     .containsExactlyEntriesOf(properties);
+        }
+
+        @Test
+        void loadShouldCallSecretPluginLoadPassingPropertiesAndContext() throws PluginException {
+            var properties = Map.of("mock-key", "mock-value");
+            var context = new PluginContext();
+            var plugin = new Properties.Plugin(TestableSecretPlugin.TYPE, properties);
+
+            var result = ((TestableSecretPlugin) loader.load(context, plugin));
+
+            assertThat(result.loadedProperties())
+                    .containsExactlyEntriesOf(properties);
+            assertThat(result.loadedContext())
+                    .isSameAs(context);
         }
     }
 

--- a/src/test/java/io/blt/gregbot/core/plugin/TestableIdentityPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/TestableIdentityPlugin.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.core.plugin;
+
+import io.blt.gregbot.plugin.PluginContext;
+import io.blt.gregbot.plugin.identities.IdentityPlugin;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class TestableIdentityPlugin implements IdentityPlugin {
+
+    static String TYPE = "io.blt.gregbot.core.plugin.TestableIdentityPlugin";
+
+    private PluginContext loadedContext;
+    private final Map<String, String> loadedProperties = new HashMap<>();
+
+    @Override
+    public Set<String> requiredProperties() {
+        return null;
+    }
+
+    @Override
+    public void load(PluginContext context, Map<String, String> properties) {
+        loadedContext = context;
+        loadedProperties.putAll(properties);
+    }
+
+    @Override
+    public Map<String, String> variables() {
+        return null;
+    }
+
+    public PluginContext loadedContext() {
+        return loadedContext;
+    }
+
+    public Map<String, String> loadedProperties() {
+        return loadedProperties;
+    }
+}

--- a/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.core.plugin;
+
+import io.blt.gregbot.plugin.secrets.SecretPlugin;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class TestableSecretPlugin implements SecretPlugin {
+    
+    static String TYPE = "io.blt.gregbot.core.plugin.TestableSecretPlugin";
+
+    private final Map<String, String> loadedProperties = new HashMap<>();
+
+    @Override
+    public Set<String> requiredProperties() {
+        return null;
+    }
+
+    @Override
+    public void load(Map<String, String> properties) {
+        loadedProperties.putAll(properties);
+    }
+
+    @Override
+    public Map<String, String> secretsForPath(String path) {
+        return null;
+    }
+
+    public Map<String, String> loadedProperties() {
+        return loadedProperties;
+    }
+}

--- a/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
@@ -8,6 +8,7 @@
 
 package io.blt.gregbot.core.plugin;
 
+import io.blt.gregbot.plugin.PluginContext;
 import io.blt.gregbot.plugin.secrets.SecretPlugin;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +18,7 @@ public class TestableSecretPlugin implements SecretPlugin {
     
     static String TYPE = "io.blt.gregbot.core.plugin.TestableSecretPlugin";
 
+    private PluginContext loadedContext;
     private final Map<String, String> loadedProperties = new HashMap<>();
 
     @Override
@@ -25,13 +27,18 @@ public class TestableSecretPlugin implements SecretPlugin {
     }
 
     @Override
-    public void load(Map<String, String> properties) {
+    public void load(PluginContext context, Map<String, String> properties) {
+        loadedContext = context;
         loadedProperties.putAll(properties);
     }
 
     @Override
     public Map<String, String> secretsForPath(String path) {
         return null;
+    }
+
+    public PluginContext loadedContext() {
+        return loadedContext;
     }
 
     public Map<String, String> loadedProperties() {

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadIdentityPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadIdentityPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.core.plugin;
+
+import io.blt.gregbot.plugin.PluginContext;
+import io.blt.gregbot.plugin.PluginException;
+import io.blt.gregbot.plugin.identities.IdentityException;
+import io.blt.gregbot.plugin.identities.IdentityPlugin;
+import java.util.Map;
+import java.util.Set;
+
+public class ThrowOnLoadIdentityPlugin implements IdentityPlugin {
+    
+    static String TYPE = "io.blt.gregbot.core.plugin.ThrowOnLoadIdentityPlugin";
+
+    @Override
+    public Set<String> requiredProperties() {
+        return null;
+    }
+
+    @Override
+    public void load(PluginContext context, Map<String, String> properties) throws PluginException {
+        throw new PluginException("identity plugin test load exception", null);
+    }
+
+    @Override
+    public Map<String, String> variables() throws IdentityException {
+        return null;
+    }
+}

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadSecretPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.core.plugin;
+
+import io.blt.gregbot.plugin.PluginContext;
+import io.blt.gregbot.plugin.PluginException;
+import io.blt.gregbot.plugin.secrets.SecretPlugin;
+import java.util.Map;
+import java.util.Set;
+
+public class ThrowOnLoadSecretPlugin implements SecretPlugin {
+    
+    static String TYPE = "io.blt.gregbot.core.plugin.ThrowOnLoadSecretPlugin";
+
+    @Override
+    public Set<String> requiredProperties() {
+        return null;
+    }
+
+    @Override
+    public void load(PluginContext context, Map<String, String> properties) throws PluginException {
+        throw new PluginException("secret plugin test load exception", null);
+    }
+
+    @Override
+    public Map<String, String> secretsForPath(String path) {
+        return null;
+    }
+
+}

--- a/src/test/java/io/blt/gregbot/core/services/IdentityServiceTest.java
+++ b/src/test/java/io/blt/gregbot/core/services/IdentityServiceTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.core.services;
+
+import io.blt.gregbot.core.plugin.TestableIdentityPlugin;
+import io.blt.gregbot.core.plugin.TestableSecretPlugin;
+import io.blt.gregbot.core.plugin.ThrowOnLoadIdentityPlugin;
+import io.blt.gregbot.core.plugin.ThrowOnLoadSecretPlugin;
+import io.blt.gregbot.core.properties.Properties.Identity;
+import io.blt.gregbot.core.properties.Properties.Plugin;
+import io.blt.gregbot.core.properties.Properties.Secret;
+import io.blt.gregbot.plugin.PluginContext;
+import io.blt.gregbot.plugin.PluginException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class IdentityServiceTest {
+
+    @Test
+    void shouldLoadAndFindIdentityPluginWithoutSecretPlugin() throws PluginException {
+        var service = new IdentityService(
+                Map.of("SecretPlugin", new Secret(
+                        new Plugin(TestableSecretPlugin.class.getName(), Map.of()))),
+                Map.of("IdentityPlugin", new Identity(
+                        null, null, Map.of(),
+                        new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
+
+        var result = service.find("IdentityPlugin");
+
+        assertThat(result)
+                .isNotEmpty().get()
+                .isInstanceOfSatisfying(TestableIdentityPlugin.class, plugin ->
+                        assertThat(plugin)
+                                .extracting(TestableIdentityPlugin::loadedContext)
+                                .extracting(PluginContext::secretPlugin)
+                                .isNull());
+    }
+
+    @Test
+    void shouldLoadAndFindIdentityPluginWithSecretPlugin() throws PluginException {
+        var service = new IdentityService(
+                Map.of("SecretPlugin", new Secret(
+                        new Plugin(TestableSecretPlugin.class.getName(), Map.of()))),
+                Map.of("IdentityPlugin", new Identity(
+                        null, "SecretPlugin", Map.of(),
+                        new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
+
+        var result = service.find("IdentityPlugin");
+
+        assertThat(result)
+                .isNotEmpty().get()
+                .isInstanceOfSatisfying(TestableIdentityPlugin.class, plugin ->
+                        assertThat(plugin)
+                                .extracting(TestableIdentityPlugin::loadedContext)
+                                .extracting(PluginContext::secretPlugin)
+                                .isInstanceOf(TestableSecretPlugin.class));
+    }
+
+    @Test
+    void findShouldReturnEmptyWhenSpecifiedIdentityDoesNotExist() throws PluginException {
+        var service = new IdentityService(Map.of(), Map.of());
+
+        var result = service.find("DoesNotExist");
+
+        assertThat(result)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldThrowWhenSpecifiedSecretPluginDoesNotExist() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new IdentityService(
+                        Map.of("SecretPlugin", new Secret(
+                                new Plugin(TestableSecretPlugin.class.getName(), Map.of()))),
+                        Map.of("IdentityPlugin", new Identity(
+                                null, "DoesNotExist", Map.of(),
+                                new Plugin(TestableIdentityPlugin.class.getName(), Map.of())))))
+                .withMessage("Cannot find secret plugin DoesNotExist");
+    }
+
+    @Test
+    void shouldBubbleUpPluginExceptionFromIdentityPlugin() {
+        assertThatExceptionOfType(PluginException.class)
+                .isThrownBy(() -> new IdentityService(
+                        Map.of(),
+                        Map.of("IdentityPlugin", new Identity(
+                                null, null, Map.of(),
+                                new Plugin(ThrowOnLoadIdentityPlugin.class.getName(), Map.of())))))
+                .withMessage("identity plugin test load exception");
+    }
+
+    @Test
+    void shouldBubbleUpPluginExceptionFromSecretPlugin() {
+        assertThatExceptionOfType(PluginException.class)
+                .isThrownBy(() -> new IdentityService(
+                        Map.of("SecretPlugin", new Secret(
+                                new Plugin(ThrowOnLoadSecretPlugin.class.getName(), Map.of()))),
+                        Map.of("IdentityPlugin", new Identity(
+                                null, "SecretPlugin", Map.of(),
+                                new Plugin(TestableIdentityPlugin.class.getName(), Map.of())))))
+                .withMessage("secret plugin test load exception");
+    }
+
+}

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
@@ -70,14 +70,14 @@ class VaultOidcTest {
         var properties = requiredPropertiesWithout(key);
 
         assertThatNullPointerException()
-                .isThrownBy(() -> new VaultOidc().load(properties));
+                .isThrownBy(() -> new VaultOidc().load(null, properties));
     }
 
     @Test
     void loadShouldNotThrowWhenPropertiesArePresent() throws Exception {
         mockVault();
 
-        doWithMockedDesktop(() -> new VaultOidc().load(requiredProperties));
+        doWithMockedDesktop(() -> new VaultOidc().load(null, requiredProperties));
     }
 
     @ParameterizedTest
@@ -88,7 +88,7 @@ class VaultOidcTest {
         var properties = requiredPropertiesWith(key, value);
 
         assertThatException()
-                .isThrownBy(() -> new VaultOidc().load(properties))
+                .isThrownBy(() -> new VaultOidc().load(null, properties))
                 .withMessageContaining(value);
     }
 
@@ -99,7 +99,7 @@ class VaultOidcTest {
         var properties = requiredPropertiesWith("listenPort", "8251");
 
         assertThatExceptionOfType(SecretException.class)
-                .isThrownBy(() -> doWithMockedDesktop(() -> new VaultOidc().load(properties)))
+                .isThrownBy(() -> doWithMockedDesktop(() -> new VaultOidc().load(null, properties)))
                 .withMessageContaining("Failed to load using properties: {host=http://mock-host, listenPort=8251}");
     }
 
@@ -108,7 +108,7 @@ class VaultOidcTest {
         mockVault();
 
         var plugin = new VaultOidc();
-        doWithMockedDesktop(() -> plugin.load(requiredProperties));
+        doWithMockedDesktop(() -> plugin.load(null, requiredProperties));
 
         var result = plugin.secretsForPath("mock/path");
 
@@ -126,7 +126,7 @@ class VaultOidcTest {
         var properties = requiredPropertiesWith("engine", "2");
 
         var plugin = new VaultOidc();
-        doWithMockedDesktop(() -> plugin.load(properties));
+        doWithMockedDesktop(() -> plugin.load(null, properties));
 
         var result = plugin.secretsForPath("mock/path");
 
@@ -144,7 +144,7 @@ class VaultOidcTest {
         var properties = requiredPropertiesWith("engine", "1");
 
         var plugin = new VaultOidc();
-        doWithMockedDesktop(() -> plugin.load(properties));
+        doWithMockedDesktop(() -> plugin.load(null, properties));
 
         var result = plugin.secretsForPath("mock/path");
 

--- a/src/test/resources/META-INF/services/io.blt.gregbot.plugin.identities.IdentityPlugin
+++ b/src/test/resources/META-INF/services/io.blt.gregbot.plugin.identities.IdentityPlugin
@@ -1,1 +1,2 @@
 io.blt.gregbot.core.plugin.TestableIdentityPlugin
+io.blt.gregbot.core.plugin.ThrowOnLoadIdentityPlugin

--- a/src/test/resources/META-INF/services/io.blt.gregbot.plugin.identities.IdentityPlugin
+++ b/src/test/resources/META-INF/services/io.blt.gregbot.plugin.identities.IdentityPlugin
@@ -1,0 +1,1 @@
+io.blt.gregbot.core.plugin.TestableIdentityPlugin

--- a/src/test/resources/META-INF/services/io.blt.gregbot.plugin.secrets.SecretPlugin
+++ b/src/test/resources/META-INF/services/io.blt.gregbot.plugin.secrets.SecretPlugin
@@ -1,1 +1,2 @@
 io.blt.gregbot.core.plugin.TestableSecretPlugin
+io.blt.gregbot.core.plugin.ThrowOnLoadSecretPlugin

--- a/src/test/resources/META-INF/services/io.blt.gregbot.plugin.secrets.SecretPlugin
+++ b/src/test/resources/META-INF/services/io.blt.gregbot.plugin.secrets.SecretPlugin
@@ -1,0 +1,1 @@
+io.blt.gregbot.core.plugin.TestableSecretPlugin


### PR DESCRIPTION
### Add `IdentityService`

The `IdentityService` is responsible for loading all Identity plugins, as well as any Secret plugin dependencies.

This requires:
1. `IdentityPlugin` interface
2. `PluginContext` passed to a plugin `load` method
    * Used to optionally pass an instance of `SecretPlugin` to an implementation of `IdentityPlugin`
