### PR TITLE
Remove requiredProperties from Plugin

### DIFF
--- a/src/main/java/io/blt/gregbot/plugin/Plugin.java
+++ b/src/main/java/io/blt/gregbot/plugin/Plugin.java
@@ -10,11 +10,8 @@ package io.blt.gregbot.plugin;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
-import java.util.Set;
 
 public interface Plugin {
-
-    Set<String> requiredProperties();
 
     void load(@NotNull Map<String, String> properties) throws PluginException;
 

--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/VaultOidc.java
@@ -19,17 +19,11 @@ import io.blt.gregbot.plugin.secrets.vault.oidc.OidcConfig;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
 public class VaultOidc implements SecretPlugin {
 
     private Vault vault;
-
-    @Override
-    public Set<String> requiredProperties() {
-        return Set.of("host");
-    }
 
     @Override
     public void load(Map<String, String> properties) throws SecretException {

--- a/src/test/java/io/blt/gregbot/core/plugin/SecretRendererTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/SecretRendererTest.java
@@ -12,7 +12,6 @@ import io.blt.gregbot.plugin.secrets.SecretException;
 import io.blt.gregbot.plugin.secrets.SecretPlugin;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -47,11 +46,6 @@ class SecretRendererTest {
         @Override
         public Map<String, String> secretsForPath(String path) {
             return secrets.get(path);
-        }
-
-        @Override
-        public Set<String> requiredProperties() {
-            return null;
         }
 
         @Override
@@ -141,11 +135,6 @@ class SecretRendererTest {
             @Override
             public Map<String, String> secretsForPath(String path) {
                 return new HashMap<>();
-            }
-
-            @Override
-            public Set<String> requiredProperties() {
-                return null;
             }
 
             @Override

--- a/src/test/java/io/blt/gregbot/core/plugin/TestableIdentityPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/TestableIdentityPlugin.java
@@ -11,18 +11,12 @@ package io.blt.gregbot.core.plugin;
 import io.blt.gregbot.plugin.identities.IdentityPlugin;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public class TestableIdentityPlugin implements IdentityPlugin {
 
     static String TYPE = "io.blt.gregbot.core.plugin.TestableIdentityPlugin";
 
     private final Map<String, String> loadedProperties = new HashMap<>();
-
-    @Override
-    public Set<String> requiredProperties() {
-        return null;
-    }
 
     @Override
     public void load(Map<String, String> properties) {

--- a/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
@@ -11,18 +11,12 @@ package io.blt.gregbot.core.plugin;
 import io.blt.gregbot.plugin.secrets.SecretPlugin;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 public class TestableSecretPlugin implements SecretPlugin {
     
     static String TYPE = "io.blt.gregbot.core.plugin.TestableSecretPlugin";
 
     private final Map<String, String> loadedProperties = new HashMap<>();
-
-    @Override
-    public Set<String> requiredProperties() {
-        return null;
-    }
 
     @Override
     public void load(Map<String, String> properties) {

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadIdentityPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadIdentityPlugin.java
@@ -12,16 +12,10 @@ import io.blt.gregbot.plugin.PluginException;
 import io.blt.gregbot.plugin.identities.IdentityException;
 import io.blt.gregbot.plugin.identities.IdentityPlugin;
 import java.util.Map;
-import java.util.Set;
 
 public class ThrowOnLoadIdentityPlugin implements IdentityPlugin {
     
     static String TYPE = "io.blt.gregbot.core.plugin.ThrowOnLoadIdentityPlugin";
-
-    @Override
-    public Set<String> requiredProperties() {
-        return null;
-    }
 
     @Override
     public void load(Map<String, String> properties) throws PluginException {

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadSecretPlugin.java
@@ -11,16 +11,10 @@ package io.blt.gregbot.core.plugin;
 import io.blt.gregbot.plugin.PluginException;
 import io.blt.gregbot.plugin.secrets.SecretPlugin;
 import java.util.Map;
-import java.util.Set;
 
 public class ThrowOnLoadSecretPlugin implements SecretPlugin {
-    
-    static String TYPE = "io.blt.gregbot.core.plugin.ThrowOnLoadSecretPlugin";
 
-    @Override
-    public Set<String> requiredProperties() {
-        return null;
-    }
+    static String TYPE = "io.blt.gregbot.core.plugin.ThrowOnLoadSecretPlugin";
 
     @Override
     public void load(Map<String, String> properties) throws PluginException {

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/VaultOidcTest.java
@@ -19,13 +19,11 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertionsProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -55,18 +53,8 @@ class VaultOidcTest {
             "host", "http://mock-host"
     );
 
-    @Test
-    void requiredPropertiesShouldReturnSetOfRequiredKeys() {
-        assertThat(new VaultOidc().requiredProperties())
-                .containsExactlyInAnyOrder("host");
-    }
-
-    static Stream<String> loadShouldThrowWhenPropertiesIsMissingKey() {
-        return new VaultOidc().requiredProperties().stream();
-    }
-
     @ParameterizedTest
-    @MethodSource
+    @CsvSource({"host"})
     void loadShouldThrowWhenPropertiesIsMissingKey(String key) {
         var properties = requiredPropertiesWithout(key);
 


### PR DESCRIPTION
### Remove `requiredProperties` from `Plugin`

This method seems redundant given that validation of properties can be performed in `Plugin#load`.

Additionally, I can imagine it being useful to have dynamic property validation e.g. if `mode` is `user` then `username` must be present - if `mode` is `service` then `api-key` must be present.