### PR TITLE
Modify Connector to raise all exceptions as IOException

### DIFF
--- a/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/VaultConnector.java
+++ b/src/main/java/io/blt/gregbot/plugin/secrets/vault/connector/VaultConnector.java
@@ -35,11 +35,7 @@ public class VaultConnector extends Connector {
                         "client_nonce", authUrlRequest.clientNonce())))
                 .build();
 
-        try {
-            return send(request, AuthUrlResponse.class);
-        } catch (InterruptedException e) {
-            throw new IOException(e);
-        }
+        return send(request, AuthUrlResponse.class);
     }
 
     public Result<CallbackResponse> fetchCallback(CallbackRequest callbackRequest) throws IOException {
@@ -55,11 +51,7 @@ public class VaultConnector extends Connector {
                 .GET()
                 .build();
 
-        try {
-            return send(request, CallbackResponse.class);
-        } catch (InterruptedException e) {
-            throw new IOException(e);
-        }
+        return send(request, CallbackResponse.class);
     }
 
 }

--- a/src/test/java/io/blt/gregbot/plugin/secrets/vault/connector/VaultConnectorTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/secrets/vault/connector/VaultConnectorTest.java
@@ -15,8 +15,6 @@ import io.blt.gregbot.plugin.secrets.vault.connector.dto.CallbackRequest;
 import io.blt.gregbot.plugin.secrets.vault.connector.dto.CallbackResponse;
 import java.io.IOException;
 import java.net.http.HttpResponse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -25,7 +23,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIOException;
 
 @WireMockTest(proxyMode = true)
 class VaultConnectorTest {
@@ -110,38 +107,6 @@ class VaultConnectorTest {
                 .get()
                 .extracting(r -> r.auth().clientToken())
                 .isEqualTo("mock-client-token");
-    }
-
-    @Nested
-    class WhenInterrupted {
-
-        final VaultConnector connector = new VaultConnector("http://mock.vault");
-
-        @BeforeEach
-        void beforeEach() {
-            Thread.currentThread().interrupt();
-        }
-
-        @Test
-        void fetchAuthUrlShouldBubbleUpInterruptedExceptionAsIOException() {
-            var request = new AuthUrlRequest("", "", "", "");
-
-            assertThatIOException()
-                    .isThrownBy(() -> connector.fetchAuthUrl(request))
-                    .havingCause()
-                    .isInstanceOf(InterruptedException.class);
-        }
-
-        @Test
-        void fetchCallbackShouldBubbleUpInterruptedExceptionAsIOException() {
-            var request = new CallbackRequest("", "", "", "", "");
-
-            assertThatIOException()
-                    .isThrownBy(() -> connector.fetchCallback(request))
-                    .havingCause()
-                    .isInstanceOf(InterruptedException.class);
-        }
-
     }
 
 }


### PR DESCRIPTION
### Modify `Connector` to raise all exceptions as `IOException`

The `Connector` class can currently throw both `IOException` and `InterruptedException`.
`VaultConnector` is currently wrapping `InterruptedException` in `IOException` to simplify code.

I'm tempted to add a `ConnectorException` and add `IOException` and `InterruptedException` as causes but when I try this the code looks worse. I can imagine revisiting this but for now I'm happy for a `Connector` to only throw `IOException`.