### PR TITLE
Add AdobeIms plugin with service support

### DIFF
--- a/src/main/java/io/blt/gregbot/plugin/connector/Connector.java
+++ b/src/main/java/io/blt/gregbot/plugin/connector/Connector.java
@@ -79,7 +79,7 @@ public class Connector {
         private final HttpResponse<byte[]> response;
         private final T data;
 
-        private Result(HttpResponse<byte[]> response, Class<T> type) {
+        protected Result(HttpResponse<byte[]> response, Class<T> type) {
             this.response = response;
             this.data = decodeResponseElseNull(response, type);
         }
@@ -90,6 +90,26 @@ public class Connector {
 
         public Optional<T> getData() {
             return Optional.ofNullable(data);
+        }
+
+        public boolean is1xxInformational() {
+            return response.statusCode() / 100 == 1;
+        }
+
+        public boolean is2xxSuccess() {
+            return response.statusCode() / 100 == 2;
+        }
+
+        public boolean is3xxRedirection() {
+            return response.statusCode() / 100 == 3;
+        }
+
+        public boolean is4xxClientError() {
+            return response.statusCode() / 100 == 4;
+        }
+
+        public boolean is5xxServerError() {
+            return response.statusCode() / 100 == 5;
         }
 
         private T decodeResponseElseNull(HttpResponse<byte[]> response, Class<T> type) {

--- a/src/main/java/io/blt/gregbot/plugin/connector/Connector.java
+++ b/src/main/java/io/blt/gregbot/plugin/connector/Connector.java
@@ -112,6 +112,10 @@ public class Connector {
             return response.statusCode() / 100 == 5;
         }
 
+        public Optional<T> successData() {
+            return is2xxSuccess() ? getData() : Optional.empty();
+        }
+
         private T decodeResponseElseNull(HttpResponse<byte[]> response, Class<T> type) {
             return nonNull(type) ? tryDecodeAsJson(response, type).orElse(null) : null;
         }

--- a/src/main/java/io/blt/gregbot/plugin/identities/adobe/AdobeIms.java
+++ b/src/main/java/io/blt/gregbot/plugin/identities/adobe/AdobeIms.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.identities.adobe;
+
+import io.blt.gregbot.plugin.PluginException;
+import io.blt.gregbot.plugin.identities.IdentityException;
+import io.blt.gregbot.plugin.identities.IdentityPlugin;
+import io.blt.gregbot.plugin.identities.adobe.connector.ImsConnector;
+import io.blt.gregbot.plugin.identities.adobe.connector.ImsServiceConnector;
+import io.blt.util.Ex;
+import java.util.Map;
+import java.util.Objects;
+
+public class AdobeIms implements IdentityPlugin {
+
+    private enum Type {
+        SERVICE
+    }
+
+    private ImsConnector connector;
+    private String variableKey;
+
+    @Override
+    public void load(Map<String, String> properties) throws PluginException {
+        var host = properties.getOrDefault("host", "https://ims-na1.adobelogin.com");
+        variableKey = properties.getOrDefault("variable", "token");
+
+        switch (parseType(properties)) {
+            case SERVICE -> {
+                var id = requireProperty(properties, "id");
+                var secret = requireProperty(properties, "secret");
+                var code = requireProperty(properties, "code");
+                var scope = properties.getOrDefault("scope", "");
+
+                connector = Ex.transformExceptions(
+                        () -> new ImsServiceConnector(host, id, secret, code, scope),
+                        e -> new PluginException("Failed to authenticate using " + host, e));
+            }
+        }
+    }
+
+    @Override
+    public Map<String, String> variables() throws IdentityException {
+        var token = Ex.transformExceptions(
+                () -> connector.token(),
+                e -> new IdentityException("Failed to refresh authentication", e));
+
+        return Map.of(variableKey, token);
+    }
+
+    private String requireProperty(Map<String, String> properties, String key) {
+        return Objects.requireNonNull(properties.get(key), "must specify '" + key + "' property");
+    }
+
+    private Type parseType(Map<String, String> properties) {
+        return Type.valueOf(requireProperty(properties, "type").toUpperCase());
+    }
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/identities/adobe/connector/ImsConnector.java
+++ b/src/main/java/io/blt/gregbot/plugin/identities/adobe/connector/ImsConnector.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.identities.adobe.connector;
+
+import java.io.IOException;
+
+public interface ImsConnector {
+
+    String token() throws IOException;
+
+}

--- a/src/main/java/io/blt/gregbot/plugin/identities/adobe/connector/ImsServiceConnector.java
+++ b/src/main/java/io/blt/gregbot/plugin/identities/adobe/connector/ImsServiceConnector.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.identities.adobe.connector;
+
+import io.blt.gregbot.plugin.connector.Connector;
+import io.blt.gregbot.plugin.identities.adobe.connector.dto.Token;
+import java.io.IOException;
+import java.net.http.HttpRequest;
+import java.util.Map;
+
+public class ImsServiceConnector extends Connector implements ImsConnector {
+
+    private final String id;
+    private final String secret;
+    private final String code;
+    private final String scope;
+
+    private Token token;
+    private long expiresAt;
+
+    public ImsServiceConnector(String host, String id, String secret, String code, String scope) throws IOException {
+        super(host);
+
+        this.id = id;
+        this.secret = secret;
+        this.code = code;
+        this.scope = scope;
+
+        issueAccessToken();
+    }
+
+    @Override
+    public String token() throws IOException {
+        if (System.currentTimeMillis() >= expiresAt) {
+            refreshAccessToken();
+        }
+
+        return token.accessToken();
+    }
+
+    private void issueAccessToken() throws IOException {
+        var request = HttpRequest.newBuilder()
+                .uri(uriForPath("/ims/token/v1"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(formFromMap(Map.of(
+                        "client_id", id,
+                        "client_secret", secret,
+                        "code", code,
+                        "scope", scope,
+                        "grant_type", "authorization_code")))
+                .build();
+
+        processResult(send(request, Token.class));
+    }
+
+    private void refreshAccessToken() throws IOException {
+        var request = HttpRequest.newBuilder()
+                .uri(uriForPath("/ims/token/v1"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(formFromMap(Map.of(
+                        "client_id", id,
+                        "client_secret", secret,
+                        "refresh_token", token.refreshToken(),
+                        "grant_type", "refresh_token")))
+                .build();
+
+        processResult(send(request, Token.class));
+    }
+
+    private void processResult(Result<Token> result) throws IOException {
+        var now = System.currentTimeMillis();
+
+        token = result
+                .successData()
+                .orElseThrow(() -> new IOException("Failed to issue auth token"));
+
+        expiresAt = now + token.expiresIn();
+    }
+}

--- a/src/main/java/io/blt/gregbot/plugin/identities/adobe/connector/dto/Token.java
+++ b/src/main/java/io/blt/gregbot/plugin/identities/adobe/connector/dto/Token.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.identities.adobe.connector.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record Token(String accessToken, String refreshToken, String tokenType, Long expiresIn) {}

--- a/src/main/resources/META-INF/services/io.blt.gregbot.plugin.identities.IdentityPlugin
+++ b/src/main/resources/META-INF/services/io.blt.gregbot.plugin.identities.IdentityPlugin
@@ -1,0 +1,1 @@
+io.blt.gregbot.plugin.identities.adobe.AdobeIms

--- a/src/test/java/io/blt/gregbot/plugin/connector/ConnectorTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/connector/ConnectorTest.java
@@ -17,13 +17,19 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -34,9 +40,14 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatIOException;
+import static org.mockito.Mockito.when;
 
 @WireMockTest(proxyMode = true)
+@ExtendWith(MockitoExtension.class)
 class ConnectorTest {
+
+    @Mock
+    HttpResponse<byte[]> httpResponse;
 
     @ParameterizedTest
     @NullAndEmptySource
@@ -87,7 +98,7 @@ class ConnectorTest {
         assertThat(result.getData())
                 .containsInstanceOf(User.class)
                 .get()
-                .extracting(User::getName)
+                .extracting(User::name)
                 .isEqualTo("Greg");
     }
 
@@ -186,6 +197,137 @@ class ConnectorTest {
 
     }
 
+    @Nested
+    class ConnectorResult {
+
+        @ParameterizedTest
+        @MethodSource("status1xx")
+        void is1xxInformationalShouldReturnTrue(int status) {
+            var result = buildResultWithStatus(status)
+                    .is1xxInformational();
+
+            assertThat(result)
+                    .isTrue();
+        }
+
+        @ParameterizedTest
+        @MethodSource({"status2xx", "status3xx", "status4xx", "status5xx"})
+        void is1xxInformationalShouldReturnFalse(int status) {
+            var result = buildResultWithStatus(status)
+                    .is1xxInformational();
+
+            assertThat(result)
+                    .isFalse();
+        }
+
+        @ParameterizedTest
+        @MethodSource("status2xx")
+        void is2xxSuccessShouldReturnTrue(int status) {
+            var result = buildResultWithStatus(status)
+                    .is2xxSuccess();
+
+            assertThat(result)
+                    .isTrue();
+        }
+
+        @ParameterizedTest
+        @MethodSource({"status1xx", "status3xx", "status4xx", "status5xx"})
+        void is2xxSuccessShouldReturnFalse(int status) {
+            var result = buildResultWithStatus(status)
+                    .is2xxSuccess();
+
+            assertThat(result)
+                    .isFalse();
+        }
+
+        @ParameterizedTest
+        @MethodSource("status3xx")
+        void is3xxRedirectionShouldReturnTrue(int status) {
+            var result = buildResultWithStatus(status)
+                    .is3xxRedirection();
+
+            assertThat(result)
+                    .isTrue();
+        }
+
+        @ParameterizedTest
+        @MethodSource({"status1xx", "status2xx", "status4xx", "status5xx"})
+        void is3xxRedirectionShouldReturnFalse(int status) {
+            var result = buildResultWithStatus(status)
+                    .is3xxRedirection();
+
+            assertThat(result)
+                    .isFalse();
+        }
+
+        @ParameterizedTest
+        @MethodSource("status4xx")
+        void is4xxClientErrorShouldReturnTrue(int status) {
+            var result = buildResultWithStatus(status)
+                    .is4xxClientError();
+
+            assertThat(result)
+                    .isTrue();
+        }
+
+        @ParameterizedTest
+        @MethodSource({"status1xx", "status2xx", "status3xx", "status5xx"})
+        void is4xxClientErrorShouldReturnFalse(int status) {
+            var result = buildResultWithStatus(status)
+                    .is4xxClientError();
+
+            assertThat(result)
+                    .isFalse();
+        }
+
+        @ParameterizedTest
+        @MethodSource("status5xx")
+        void is5xxServerErrorShouldReturnTrue(int status) {
+            var result = buildResultWithStatus(status)
+                    .is5xxServerError();
+
+            assertThat(result)
+                    .isTrue();
+        }
+
+        @ParameterizedTest
+        @MethodSource({"status1xx", "status2xx", "status3xx", "status4xx"})
+        void is5xxServerErrorShouldReturnFalse(int status) {
+            var result = buildResultWithStatus(status)
+                    .is5xxServerError();
+
+            assertThat(result)
+                    .isFalse();
+        }
+
+        Connector.Result<String> buildResultWithStatus(int status) {
+            when(httpResponse.statusCode()).thenReturn(status);
+
+            return new Connector.Result<>(httpResponse, null);
+        }
+
+        private static Stream<Integer> status1xx() {
+            return IntStream.range(100, 200).boxed();
+        }
+
+        static Stream<Integer> status2xx() {
+            return IntStream.range(200, 300).boxed();
+        }
+
+        static Stream<Integer> status3xx() {
+            return IntStream.range(300, 400).boxed();
+        }
+
+        static Stream<Integer> status4xx() {
+            return IntStream.range(400, 500).boxed();
+        }
+
+        static Stream<Integer> status5xx() {
+            return IntStream.range(500, 600).boxed();
+        }
+
+    }
+
     private void mockEndpointReturning(ResponseDefinitionBuilder responseDefinitionBuilder) {
         stubFor(get("/mock/path")
                 .withHost(equalTo("mock.domain"))
@@ -202,17 +344,6 @@ class ConnectorTest {
         stubFor(builder);
     }
 
-    public static class User {
-        private String name;
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-    }
-
+    record User(String name) {}
 
 }

--- a/src/test/java/io/blt/gregbot/plugin/connector/ConnectorTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/connector/ConnectorTest.java
@@ -300,10 +300,46 @@ class ConnectorTest {
                     .isFalse();
         }
 
-        Connector.Result<String> buildResultWithStatus(int status) {
-            when(httpResponse.statusCode()).thenReturn(status);
+        @ParameterizedTest
+        @MethodSource("status2xx")
+        void successDataShouldReturnDataWhenStatusIs2xxAndDataIsNotEmpty(int status) {
+            var result = buildResultWithBodyAndStatus("\"test\"", status)
+                    .successData();
 
-            return new Connector.Result<>(httpResponse, null);
+            assertThat(result)
+                    .isNotEmpty()
+                    .contains("test");
+        }
+
+        @ParameterizedTest
+        @MethodSource("status2xx")
+        void successDataShouldReturnEmptyWhenStatusIs2xxAndDataIsEmpty(int status) {
+            var result = buildResultWithBodyAndStatus("", status)
+                    .successData();
+
+            assertThat(result)
+                    .isEmpty();
+        }
+
+        @ParameterizedTest
+        @MethodSource({"status1xx", "status3xx", "status4xx", "status5xx"})
+        void successDataShouldReturnEmptyWhenStatusIsNot2xxAndDataIsNotEmpty(int status) {
+            var result = buildResultWithBodyAndStatus("\"test\"", status)
+                    .successData();
+
+            assertThat(result)
+                    .isEmpty();
+        }
+
+        Connector.Result<String> buildResultWithStatus(int status) {
+            return buildResultWithBodyAndStatus("", status);
+        }
+
+        Connector.Result<String> buildResultWithBodyAndStatus(String body, int status) {
+            when(httpResponse.statusCode()).thenReturn(status);
+            when(httpResponse.body()).thenReturn(body.getBytes());
+
+            return new Connector.Result<>(httpResponse, String.class);
         }
 
         private static Stream<Integer> status1xx() {

--- a/src/test/java/io/blt/gregbot/plugin/identities/adobe/AdobeImsTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/identities/adobe/AdobeImsTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2024 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.identities.adobe;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.blt.gregbot.plugin.PluginException;
+import io.blt.gregbot.plugin.identities.IdentityException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.entry;
+
+@WireMockTest(proxyMode = true)
+class AdobeImsTest {
+
+    @Nested
+    class Service {
+
+        final Map<String, String> requiredProperties = Map.of(
+                "type", "SERVICE",
+                "id", "mock-id",
+                "secret", "mock-secret",
+                "code", "mock-code"
+        );
+
+        @ParameterizedTest
+        @CsvSource({"type", "id", "secret", "code"})
+        void loadShouldThrowWhenPropertiesIsMissingKey(String key) {
+            var properties = requiredPropertiesWithout(key);
+
+            assertThatNullPointerException()
+                    .isThrownBy(() -> new AdobeIms().load(properties));
+        }
+
+        @Test
+        void loadShouldDefaultHostProperty() {
+            assertThatException()
+                    .isThrownBy(() -> new AdobeIms().load(requiredProperties))
+                    .withMessage("Failed to authenticate using https://ims-na1.adobelogin.com");
+        }
+
+        @Test
+        void loadShouldOverrideDefaultHostProperty() {
+            var properties = requiredPropertiesWith("host", "https://mock-host");
+
+            assertThatException()
+                    .isThrownBy(() -> new AdobeIms().load(properties))
+                    .withMessage("Failed to authenticate using https://mock-host");
+        }
+
+        @Test
+        void variablesShouldReturnResultUsingDefaultPropertyValues() throws PluginException {
+            mockIms("");
+
+            var plugin = new AdobeIms();
+            // Mocking the default https address requires modifying HttpClient which I want to avoid.
+            // Instead, I'll test the host in loadShouldDefaultHostProperty and loadShouldOverrideDefaultHostProperty
+            plugin.load(requiredPropertiesWith("host", "http://mock-host"));
+            var result = plugin.variables();
+
+            assertThat(result)
+                    .containsOnly(entry("token", "mock-access-token"));
+        }
+
+        @Test
+        void variablesShouldReturnResultUsingOverriddenPropertyValues() throws PluginException {
+            mockIms("mock-scope");
+
+            var properties = new HashMap<>(requiredProperties);
+            properties.putAll(Map.of(
+                    "host", "http://mock-host",
+                    "variable", "mock-variable",
+                    "scope", "mock-scope"));
+
+            var plugin = new AdobeIms();
+            plugin.load(properties);
+            var result = plugin.variables();
+
+            assertThat(result)
+                    .containsOnly(entry("mock-variable", "mock-access-token"));
+        }
+
+        @Test
+        void variablesShouldBubbleUpConnectorExceptionWrappedInIdentityException() throws PluginException {
+            mockImsSeverError();
+
+            var plugin = new AdobeIms();
+            plugin.load(requiredPropertiesWith("host", "http://mock-host"));
+
+            assertThatExceptionOfType(IdentityException.class)
+                    .isThrownBy(plugin::variables);
+        }
+
+        private Map<String, String> requiredPropertiesWithout(String key) {
+            var properties = new HashMap<>(requiredProperties);
+            properties.remove(key);
+            return properties;
+        }
+
+        private Map<String, String> requiredPropertiesWith(String key, String value) {
+            var properties = new HashMap<>(requiredProperties);
+            properties.put(key, value);
+            return properties;
+        }
+
+        private void mockIms(String scope) {
+            stubFor(post("/ims/token/v1")
+                    .withHost(equalTo("mock-host"))
+                    .withFormParam("client_id", equalTo("mock-id"))
+                    .withFormParam("client_secret", equalTo("mock-secret"))
+                    .withFormParam("code", equalTo("mock-code"))
+                    .withFormParam("scope", equalTo(scope))
+                    .withFormParam("grant_type", equalTo("authorization_code"))
+                    .willReturn(okJson("""
+                            {
+                              "access_token": "mock-access-token",
+                              "expires_in": 1000
+                            }
+                            """)));
+        }
+
+        private void mockImsSeverError() {
+            stubFor(post("/ims/token/v1")
+                    .withHost(equalTo("mock-host"))
+                    .withFormParam("client_id", equalTo("mock-id"))
+                    .withFormParam("client_secret", equalTo("mock-secret"))
+                    .withFormParam("code", equalTo("mock-code"))
+                    .withFormParam("scope", equalTo(""))
+                    .withFormParam("grant_type", equalTo("authorization_code"))
+                    .willReturn(okJson("""
+                            {
+                              "access_token": "mock-access-token",
+                              "refresh_token" : "mock-refresh-token",
+                              "expires_in": 0
+                            }
+                            """)));
+
+            stubFor(post("/ims/token/v1")
+                    .withHost(equalTo("mock-host"))
+                    .withFormParam("client_id", equalTo("mock-id"))
+                    .withFormParam("client_secret", equalTo("mock-secret"))
+                    .withFormParam("refresh_token", equalTo("mock-refresh-token"))
+                    .withFormParam("grant_type", equalTo("refresh_token"))
+                    .willReturn(serverError()));
+        }
+
+    }
+
+}

--- a/src/test/java/io/blt/gregbot/plugin/identities/adobe/connector/ImsServiceConnectorTest.java
+++ b/src/test/java/io/blt/gregbot/plugin/identities/adobe/connector/ImsServiceConnectorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.plugin.identities.adobe.connector;
+
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WireMockTest(proxyMode = true)
+class ImsServiceConnectorTest {
+
+    @Test
+    void tokenShouldReturnIssuedAccessToken() throws IOException {
+        stubFor(issueAccessToken()
+                .willReturn(okJson("""
+                        {
+                          "access_token": "mock-access-token",
+                          "expires_in": 1000
+                        }
+                        """)));
+
+        var result = new ImsServiceConnector("http://mock.ims", "mock-id", "mock-secret", "mock-code", "mock-scope")
+                .token();
+
+        assertThat(result)
+                .isEqualTo("mock-access-token");
+    }
+
+    @Test
+    void tokenShouldRefreshAccessTokenWhenExpires() throws IOException {
+        stubFor(issueAccessToken()
+                .willReturn(okJson("""
+                        {
+                          "refresh_token": "mock-refresh-token",
+                          "expires_in": 0
+                        }
+                        """)));
+
+        stubFor(refreshAccessToken("mock-refresh-token")
+                .willReturn(okJson("""
+                        {
+                          "access_token": "mock-refreshed-access-token",
+                          "expires_in": 1000
+                        }
+                        """)));
+
+        var result = new ImsServiceConnector("http://mock.ims", "mock-id", "mock-secret", "mock-code", "mock-scope")
+                .token();
+
+        assertThat(result)
+                .isEqualTo("mock-refreshed-access-token");
+    }
+
+    private MappingBuilder issueAccessToken() {
+        return post("/ims/token/v1")
+                .withHost(equalTo("mock.ims"))
+                .withFormParam("client_id", equalTo("mock-id"))
+                .withFormParam("client_secret", equalTo("mock-secret"))
+                .withFormParam("code", equalTo("mock-code"))
+                .withFormParam("scope", equalTo("mock-scope"))
+                .withFormParam("grant_type", equalTo("authorization_code"));
+    }
+
+    private MappingBuilder refreshAccessToken(String refreshToken) {
+        return post("/ims/token/v1")
+                .withHost(equalTo("mock.ims"))
+                .withFormParam("client_id", equalTo("mock-id"))
+                .withFormParam("client_secret", equalTo("mock-secret"))
+                .withFormParam("refresh_token", equalTo(refreshToken))
+                .withFormParam("grant_type", equalTo("refresh_token"));
+    }
+
+}


### PR DESCRIPTION
### Add `AdobeIms` plugin with service support

Adds an `AdobeIms` identity plugin with an support for service token authentication.

The intention is to extend the capabilities of the plugin in the future to also support user tokens.