### PR TITLE
Modify IdentityService to return resolved variables

### DIFF
--- a/src/main/java/io/blt/gregbot/core/plugin/PluginLoader.java
+++ b/src/main/java/io/blt/gregbot/core/plugin/PluginLoader.java
@@ -58,7 +58,8 @@ public class PluginLoader<T extends Plugin> {
                 .filter(p -> providerType(p).equals(plugin.type()))
                 .map(ServiceLoader.Provider::get)
                 .collect(toOptional())
-                .orElseThrow();
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Cannot find plugin '%s'".formatted(plugin.type())));
     }
 
     private String providerType(ServiceLoader.Provider<T> provider) {

--- a/src/main/java/io/blt/gregbot/core/plugin/PluginLoader.java
+++ b/src/main/java/io/blt/gregbot/core/plugin/PluginLoader.java
@@ -36,6 +36,7 @@ public class PluginLoader<T extends Plugin> {
      * @return a new loaded plugin instance
      * @throws PluginException        if there is an error loading the plugin
      * @throws NoSuchElementException if no plugin matches the properties
+     * @throws NullPointerException   if {@code plugin} is {@code null}
      */
     public T load(Properties.Plugin plugin) throws PluginException {
         return Obj.poke(findPluginOrThrow(plugin), p -> p.load(plugin.properties()));

--- a/src/main/java/io/blt/gregbot/core/services/IdentityService.java
+++ b/src/main/java/io/blt/gregbot/core/services/IdentityService.java
@@ -22,6 +22,7 @@ import io.blt.util.Ex;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.commons.lang3.Validate;
 
 import static java.util.Objects.isNull;
 
@@ -84,11 +85,7 @@ public class IdentityService {
 
     private Secret findSecret(Identity identity) {
         var name = identity.secrets();
-        var result = secrets.get(name);
-        if (isNull(result)) {
-            throw new IllegalArgumentException("Cannot find secret plugin " + name);
-        }
-        return result;
+        return Validate.notNull(secrets.get(name), "Cannot find secret plugin '%s'", name);
     }
 
     private SecretRenderer getOrComputeSecretRenderer(Secret secret) throws PluginException {

--- a/src/main/java/io/blt/gregbot/core/services/IdentityService.java
+++ b/src/main/java/io/blt/gregbot/core/services/IdentityService.java
@@ -67,10 +67,10 @@ public class IdentityService {
 
     private IdentityPlugin loadIdentityPlugin(Identity identity) throws PluginException, SecretRenderException {
         var loader = new PluginLoader<>(IdentityPlugin.class);
-        return loader.load(resolvedPluginProperties(identity));
+        return loader.load(renderedPluginProperties(identity));
     }
 
-    private Properties.Plugin resolvedPluginProperties(Identity identity)
+    private Properties.Plugin renderedPluginProperties(Identity identity)
             throws SecretRenderException, PluginException {
         if (isNull(identity.secrets())) {
             return identity.plugin();

--- a/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
@@ -72,9 +72,9 @@ class PluginLoaderTest {
             var properties = Map.of("mock-key", "mock-value");
             var plugin = new Properties.Plugin(TestableSecretPlugin.TYPE, properties);
 
-            var result = ((TestableSecretPlugin) loader.load(plugin));
+            loader.load(plugin);
 
-            assertThat(result.loadedProperties())
+            assertThat(TestableSecretPlugin.loadedProperties())
                     .containsExactlyEntriesOf(properties);
         }
 
@@ -143,9 +143,9 @@ class PluginLoaderTest {
             var properties = Map.of("mock-key", "mock-value");
             var plugin = new Properties.Plugin(TestableIdentityPlugin.TYPE, properties);
 
-            var result = ((TestableIdentityPlugin) loader.load(plugin));
+            loader.load(plugin);
 
-            assertThat(result.loadedProperties())
+            assertThat(TestableIdentityPlugin.loadedProperties())
                     .containsExactlyEntriesOf(properties);
         }
 

--- a/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
@@ -79,6 +79,12 @@ class PluginLoaderTest {
         }
 
         @Test
+        void loadShouldThrowWhenSpecifiedPluginIsNull() {
+            assertThatExceptionOfType(NullPointerException.class)
+                    .isThrownBy(() -> loader.load(null));
+        }
+
+        @Test
         void loadShouldThrowWhenPluginTypeCannotBeFound() {
             var plugin = new Properties.Plugin("UnknownType", Map.of());
 
@@ -140,6 +146,12 @@ class PluginLoaderTest {
 
             assertThat(result.loadedProperties())
                     .containsExactlyEntriesOf(properties);
+        }
+
+        @Test
+        void loadShouldThrowWhenSpecifiedPluginIsNull() {
+            assertThatExceptionOfType(NullPointerException.class)
+                    .isThrownBy(() -> loader.load(null));
         }
 
         @Test

--- a/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
@@ -99,7 +99,7 @@ class PluginLoaderTest {
 
             assertThatExceptionOfType(PluginException.class)
                     .isThrownBy(() -> loader.load(plugin))
-                    .withMessage("secret plugin test load exception");
+                    .withMessage(ThrowOnLoadSecretPlugin.MESSAGE);
         }
     }
 
@@ -170,7 +170,7 @@ class PluginLoaderTest {
 
             assertThatExceptionOfType(PluginException.class)
                     .isThrownBy(() -> loader.load(plugin))
-                    .withMessage("identity plugin test load exception");
+                    .withMessage(ThrowOnLoadIdentityPlugin.MESSAGE);
         }
     }
 

--- a/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
@@ -86,10 +86,11 @@ class PluginLoaderTest {
 
         @Test
         void loadShouldThrowWhenPluginTypeCannotBeFound() {
-            var plugin = new Properties.Plugin("UnknownType", Map.of());
+            var plugin = new Properties.Plugin("UnknownSecretPluginType", Map.of());
 
             assertThatExceptionOfType(NoSuchElementException.class)
-                    .isThrownBy(() -> loader.load(plugin));
+                    .isThrownBy(() -> loader.load(plugin))
+                    .withMessage("Cannot find plugin 'UnknownSecretPluginType'");
         }
 
         @Test
@@ -156,10 +157,11 @@ class PluginLoaderTest {
 
         @Test
         void loadShouldThrowWhenPluginTypeCannotBeFound() {
-            var plugin = new Properties.Plugin("UnknownType", Map.of());
+            var plugin = new Properties.Plugin("UnknownIdentityPluginType", Map.of());
 
             assertThatExceptionOfType(NoSuchElementException.class)
-                    .isThrownBy(() -> loader.load(plugin));
+                    .isThrownBy(() -> loader.load(plugin))
+                    .withMessage("Cannot find plugin 'UnknownIdentityPluginType'");
         }
 
         @Test

--- a/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/PluginLoaderTest.java
@@ -43,12 +43,12 @@ class PluginLoaderTest {
 
             assertThat(plugins)
                     .isNotEmpty()
-                    .contains(TestableSecretPlugin.TYPE);
+                    .contains(TestableSecretPlugin.class.getName());
         }
 
         @Test
         void loadShouldReturnInstanceOfSecretPlugin() throws PluginException {
-            var plugin = new Properties.Plugin(TestableSecretPlugin.TYPE, Map.of());
+            var plugin = new Properties.Plugin(TestableSecretPlugin.class.getName(), Map.of());
 
             var result = loader.load(plugin);
 
@@ -58,7 +58,7 @@ class PluginLoaderTest {
 
         @Test
         void loadShouldReturnDifferentInstanceOfSecretPluginOnEachCall() throws PluginException {
-            var plugin = new Properties.Plugin(TestableSecretPlugin.TYPE, Map.of());
+            var plugin = new Properties.Plugin(TestableSecretPlugin.class.getName(), Map.of());
 
             var result1 = loader.load(plugin);
             var result2 = loader.load(plugin);
@@ -70,7 +70,7 @@ class PluginLoaderTest {
         @Test
         void loadShouldCallSecretPluginLoadPassingProperties() throws PluginException {
             var properties = Map.of("mock-key", "mock-value");
-            var plugin = new Properties.Plugin(TestableSecretPlugin.TYPE, properties);
+            var plugin = new Properties.Plugin(TestableSecretPlugin.class.getName(), properties);
 
             loader.load(plugin);
 
@@ -95,7 +95,7 @@ class PluginLoaderTest {
 
         @Test
         void loadShouldThrowWhenPluginLoadThrows() {
-            var plugin = new Properties.Plugin(ThrowOnLoadSecretPlugin.TYPE, Map.of());
+            var plugin = new Properties.Plugin(ThrowOnLoadSecretPlugin.class.getName(), Map.of());
 
             assertThatExceptionOfType(PluginException.class)
                     .isThrownBy(() -> loader.load(plugin))
@@ -114,12 +114,12 @@ class PluginLoaderTest {
 
             assertThat(plugins)
                     .isNotEmpty()
-                    .contains(TestableIdentityPlugin.TYPE);
+                    .contains(TestableIdentityPlugin.class.getName());
         }
 
         @Test
         void loadShouldReturnInstanceOfIdentityPlugin() throws PluginException {
-            var plugin = new Properties.Plugin(TestableIdentityPlugin.TYPE, Map.of());
+            var plugin = new Properties.Plugin(TestableIdentityPlugin.class.getName(), Map.of());
 
             var result = loader.load(plugin);
 
@@ -129,7 +129,7 @@ class PluginLoaderTest {
 
         @Test
         void loadShouldReturnDifferentInstanceOfIdentityPluginOnEachCall() throws PluginException {
-            var plugin = new Properties.Plugin(TestableIdentityPlugin.TYPE, Map.of());
+            var plugin = new Properties.Plugin(TestableIdentityPlugin.class.getName(), Map.of());
 
             var result1 = loader.load(plugin);
             var result2 = loader.load(plugin);
@@ -141,7 +141,7 @@ class PluginLoaderTest {
         @Test
         void loadShouldCallIdentityPluginLoadPassingProperties() throws PluginException {
             var properties = Map.of("mock-key", "mock-value");
-            var plugin = new Properties.Plugin(TestableIdentityPlugin.TYPE, properties);
+            var plugin = new Properties.Plugin(TestableIdentityPlugin.class.getName(), properties);
 
             loader.load(plugin);
 
@@ -166,7 +166,7 @@ class PluginLoaderTest {
 
         @Test
         void loadShouldThrowWhenPluginLoadThrows() {
-            var plugin = new Properties.Plugin(ThrowOnLoadIdentityPlugin.TYPE, Map.of());
+            var plugin = new Properties.Plugin(ThrowOnLoadIdentityPlugin.class.getName(), Map.of());
 
             assertThatExceptionOfType(PluginException.class)
                     .isThrownBy(() -> loader.load(plugin))

--- a/src/test/java/io/blt/gregbot/core/plugin/TestableIdentityPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/TestableIdentityPlugin.java
@@ -14,9 +14,14 @@ import java.util.Map;
 
 public class TestableIdentityPlugin implements IdentityPlugin {
 
-    static String TYPE = "io.blt.gregbot.core.plugin.TestableIdentityPlugin";
+    static final String TYPE = "io.blt.gregbot.core.plugin.TestableIdentityPlugin";
 
     private static Map<String, String> loadedProperties;
+    private static int instanceCount = 0;
+
+    public TestableIdentityPlugin() {
+        instanceCount++;
+    }
 
     @Override
     public void load(Map<String, String> properties) {
@@ -31,5 +36,13 @@ public class TestableIdentityPlugin implements IdentityPlugin {
 
     public static Map<String, String> loadedProperties() {
         return loadedProperties;
+    }
+
+    public static int instanceCount() {
+        return instanceCount;
+    }
+
+    public static void resetInstanceCount() {
+        instanceCount = 0;
     }
 }

--- a/src/test/java/io/blt/gregbot/core/plugin/TestableIdentityPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/TestableIdentityPlugin.java
@@ -16,19 +16,20 @@ public class TestableIdentityPlugin implements IdentityPlugin {
 
     static String TYPE = "io.blt.gregbot.core.plugin.TestableIdentityPlugin";
 
-    private final Map<String, String> loadedProperties = new HashMap<>();
+    private static Map<String, String> loadedProperties;
 
     @Override
     public void load(Map<String, String> properties) {
+        loadedProperties = new HashMap<>();
         loadedProperties.putAll(properties);
     }
 
     @Override
     public Map<String, String> variables() {
-        return null;
+        return Map.of("identity-plugin-key", "identity-plugin-value");
     }
 
-    public Map<String, String> loadedProperties() {
+    public static Map<String, String> loadedProperties() {
         return loadedProperties;
     }
 }

--- a/src/test/java/io/blt/gregbot/core/plugin/TestableIdentityPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/TestableIdentityPlugin.java
@@ -14,8 +14,6 @@ import java.util.Map;
 
 public class TestableIdentityPlugin implements IdentityPlugin {
 
-    static final String TYPE = "io.blt.gregbot.core.plugin.TestableIdentityPlugin";
-
     private static Map<String, String> loadedProperties;
     private static int instanceCount = 0;
 

--- a/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
@@ -14,8 +14,6 @@ import java.util.Map;
 
 public class TestableSecretPlugin implements SecretPlugin {
 
-    static final String TYPE = "io.blt.gregbot.core.plugin.TestableSecretPlugin";
-
     private static Map<String, String> loadedProperties;
     private static int instanceCount = 0;
 

--- a/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
@@ -16,19 +16,20 @@ public class TestableSecretPlugin implements SecretPlugin {
     
     static String TYPE = "io.blt.gregbot.core.plugin.TestableSecretPlugin";
 
-    private final Map<String, String> loadedProperties = new HashMap<>();
+    private static Map<String, String> loadedProperties;
 
     @Override
     public void load(Map<String, String> properties) {
+        loadedProperties = new HashMap<>();
         loadedProperties.putAll(properties);
     }
 
     @Override
     public Map<String, String> secretsForPath(String path) {
-        return Map.of("test-secret", path + "-test-value");
+        return Map.of("secret-key", path + "/secret-value");
     }
 
-    public Map<String, String> loadedProperties() {
+    public static Map<String, String> loadedProperties() {
         return loadedProperties;
     }
 }

--- a/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/TestableSecretPlugin.java
@@ -13,10 +13,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class TestableSecretPlugin implements SecretPlugin {
-    
-    static String TYPE = "io.blt.gregbot.core.plugin.TestableSecretPlugin";
+
+    static final String TYPE = "io.blt.gregbot.core.plugin.TestableSecretPlugin";
 
     private static Map<String, String> loadedProperties;
+    private static int instanceCount = 0;
+
+    public TestableSecretPlugin() {
+        instanceCount++;
+    }
 
     @Override
     public void load(Map<String, String> properties) {
@@ -31,5 +36,13 @@ public class TestableSecretPlugin implements SecretPlugin {
 
     public static Map<String, String> loadedProperties() {
         return loadedProperties;
+    }
+
+    public static int instanceCount() {
+        return instanceCount;
+    }
+
+    public static void resetInstanceCount() {
+        instanceCount = 0;
     }
 }

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadIdentityPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadIdentityPlugin.java
@@ -9,13 +9,10 @@
 package io.blt.gregbot.core.plugin;
 
 import io.blt.gregbot.plugin.PluginException;
-import io.blt.gregbot.plugin.identities.IdentityException;
 import io.blt.gregbot.plugin.identities.IdentityPlugin;
 import java.util.Map;
 
 public class ThrowOnLoadIdentityPlugin implements IdentityPlugin {
-    
-    static String TYPE = "io.blt.gregbot.core.plugin.ThrowOnLoadIdentityPlugin";
 
     @Override
     public void load(Map<String, String> properties) throws PluginException {
@@ -23,7 +20,7 @@ public class ThrowOnLoadIdentityPlugin implements IdentityPlugin {
     }
 
     @Override
-    public Map<String, String> variables() throws IdentityException {
+    public Map<String, String> variables() {
         return null;
     }
 }

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadIdentityPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadIdentityPlugin.java
@@ -14,9 +14,11 @@ import java.util.Map;
 
 public class ThrowOnLoadIdentityPlugin implements IdentityPlugin {
 
+    public static final String MESSAGE = "identity plugin exception on load";
+
     @Override
     public void load(Map<String, String> properties) throws PluginException {
-        throw new PluginException("identity plugin test load exception", null);
+        throw new PluginException(MESSAGE, null);
     }
 
     @Override

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadSecretPlugin.java
@@ -14,10 +14,11 @@ import java.util.Map;
 
 public class ThrowOnLoadSecretPlugin implements SecretPlugin {
 
+    public static final String MESSAGE = "secret plugin exception on load";
 
     @Override
     public void load(Map<String, String> properties) throws PluginException {
-        throw new PluginException("secret plugin test load exception", null);
+        throw new PluginException(MESSAGE, null);
     }
 
     @Override

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnLoadSecretPlugin.java
@@ -14,7 +14,6 @@ import java.util.Map;
 
 public class ThrowOnLoadSecretPlugin implements SecretPlugin {
 
-    static String TYPE = "io.blt.gregbot.core.plugin.ThrowOnLoadSecretPlugin";
 
     @Override
     public void load(Map<String, String> properties) throws PluginException {

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnSecretsForPathSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnSecretsForPathSecretPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.core.plugin;
+
+import io.blt.gregbot.plugin.PluginException;
+import io.blt.gregbot.plugin.secrets.SecretException;
+import io.blt.gregbot.plugin.secrets.SecretPlugin;
+import java.util.Map;
+
+public class ThrowOnSecretsForPathSecretPlugin implements SecretPlugin {
+
+    public static final String MESSAGE = "secret plugin exception on secretsForPath";
+
+    @Override
+    public void load(Map<String, String> properties) throws PluginException { }
+
+    @Override
+    public Map<String, String> secretsForPath(String path) throws SecretException {
+        throw new SecretException(MESSAGE, null);
+    }
+
+}

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnSecretsForPathSecretPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnSecretsForPathSecretPlugin.java
@@ -18,7 +18,9 @@ public class ThrowOnSecretsForPathSecretPlugin implements SecretPlugin {
     public static final String MESSAGE = "secret plugin exception on secretsForPath";
 
     @Override
-    public void load(Map<String, String> properties) throws PluginException { }
+    public void load(Map<String, String> properties) throws PluginException {
+        // Don't need the test plugin to load properties
+    }
 
     @Override
     public Map<String, String> secretsForPath(String path) throws SecretException {

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnVariablesIdentityPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnVariablesIdentityPlugin.java
@@ -18,7 +18,9 @@ public class ThrowOnVariablesIdentityPlugin implements IdentityPlugin {
     public static final String MESSAGE = "identity plugin exception on variables";
 
     @Override
-    public void load(Map<String, String> properties) throws PluginException { }
+    public void load(Map<String, String> properties) throws PluginException {
+        // Don't need the test plugin to load properties
+    }
 
     @Override
     public Map<String, String> variables() throws IdentityException {

--- a/src/test/java/io/blt/gregbot/core/plugin/ThrowOnVariablesIdentityPlugin.java
+++ b/src/test/java/io/blt/gregbot/core/plugin/ThrowOnVariablesIdentityPlugin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 Mike Cowan.
+ *
+ * This source code is subject to the terms of the GNU General Public
+ * License, version 3. If a copy of the GPL was not distributed with this
+ * file, You can obtain one at: https://www.gnu.org/licenses/gpl-3.0.txt
+ */
+
+package io.blt.gregbot.core.plugin;
+
+import io.blt.gregbot.plugin.PluginException;
+import io.blt.gregbot.plugin.identities.IdentityException;
+import io.blt.gregbot.plugin.identities.IdentityPlugin;
+import java.util.Map;
+
+public class ThrowOnVariablesIdentityPlugin implements IdentityPlugin {
+
+    public static final String MESSAGE = "identity plugin exception on variables";
+
+    @Override
+    public void load(Map<String, String> properties) throws PluginException { }
+
+    @Override
+    public Map<String, String> variables() throws IdentityException {
+        throw new IdentityException(MESSAGE, null);
+    }
+}

--- a/src/test/java/io/blt/gregbot/core/services/IdentityServiceTest.java
+++ b/src/test/java/io/blt/gregbot/core/services/IdentityServiceTest.java
@@ -15,14 +15,17 @@ import io.blt.gregbot.core.plugin.ThrowOnLoadSecretPlugin;
 import io.blt.gregbot.core.properties.Properties.Identity;
 import io.blt.gregbot.core.properties.Properties.Plugin;
 import io.blt.gregbot.core.properties.Properties.Secret;
-import io.blt.gregbot.plugin.PluginException;
+import io.blt.gregbot.plugin.identities.IdentityPlugin;
+import io.blt.gregbot.plugin.secrets.SecretPlugin;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.data.MapEntry.entry;
 
 class IdentityServiceTest {
 
@@ -43,107 +46,346 @@ class IdentityServiceTest {
                         new Plugin(ThrowOnLoadIdentityPlugin.class.getName(), Map.of()))));
     }
 
-    @Test
-    void shouldLoadAndFindIdentityPluginWithoutSecretPlugin() throws IdentityServiceException {
-        var service = new IdentityService(
-                Map.of("SecretPlugin", new Secret(
-                        new Plugin(TestableSecretPlugin.class.getName(), Map.of()))),
-                Map.of("IdentityPlugin", new Identity(
-                        null, null, Map.of(),
-                        new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
+    @Nested
+    class VariablesFor {
 
-        var result = service.find("IdentityPlugin");
+        @Test
+        void shouldReturnIdentityVariablesWithoutPlugin() throws Exception {
+            var service = new IdentityService(
+                    Map.of(),
+                    Map.of("MockIdentity",
+                            new Identity(null, null, Map.of("plain-key", "plain-value"), null)));
 
-        assertThat(result)
-                .isNotEmpty().get()
-                .isInstanceOf(TestableIdentityPlugin.class);
+            var variables = service.variablesFor("MockIdentity");
+
+            assertThat(variables)
+                    .containsOnly(
+                            entry("plain-key", "plain-value"));
+        }
+
+        @Test
+        void shouldReturnIdentityVariablesWithPlugin() throws Exception {
+            var service = new IdentityService(
+                    Map.of(),
+                    Map.of("MockIdentity",
+                            new Identity(null, null, Map.of("plain-key", "plain-value"),
+                                    new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
+
+            var variables = service.variablesFor("MockIdentity");
+
+            assertThat(variables)
+                    .containsOnly(
+                            entry("plain-key", "plain-value"),
+                            entry("identity-plugin-key", "identity-plugin-value"));
+        }
+
+        @Test
+        void shouldReturnIdentityVariablesWithPluginWithSecretPlugin() throws Exception {
+            var service = new IdentityService(
+                    Map.of("MockSecret",
+                            new Secret(new Plugin(TestableSecretPlugin.class.getName(), Map.of()))),
+                    Map.of("MockIdentity",
+                            new Identity(null, "MockSecret", Map.of("plain-key", "plain-value"),
+                                    new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
+
+            var variables = service.variablesFor("MockIdentity");
+
+            assertThat(variables)
+                    .containsOnly(
+                            entry("plain-key", "plain-value"),
+                            entry("identity-plugin-key", "identity-plugin-value"));
+        }
+
+        @Test
+        void shouldLoadIdentityPluginWithIdentityPluginProperties() throws Exception {
+            var service = new IdentityService(
+                    Map.of(),
+                    Map.of("MockIdentity",
+                            new Identity(null, null, Map.of(),
+                                    new Plugin(TestableIdentityPlugin.class.getName(),
+                                            Map.of("plugin-key", "plugin-value")))));
+
+            service.variablesFor("MockIdentity");
+
+            assertThat(TestableIdentityPlugin.loadedProperties())
+                    .containsOnly(
+                            entry("plugin-key", "plugin-value"));
+        }
+
+        @Test
+        void shouldLoadIdentityPluginWithRenderedSecrets() throws Exception {
+            var service = new IdentityService(
+                    Map.of("MockSecret",
+                            new Secret(new Plugin(TestableSecretPlugin.class.getName(), Map.of()))),
+                    Map.of("MockIdentity",
+                            new Identity(null, "MockSecret", Map.of(),
+                                    new Plugin(TestableIdentityPlugin.class.getName(),
+                                            Map.of("rendered-key", "rendered-[secret-path/secret-key]")))));
+
+            service.variablesFor("MockIdentity");
+
+            assertThat(TestableIdentityPlugin.loadedProperties())
+                    .containsOnly(
+                            entry("rendered-key", "rendered-secret-path/secret-value"));
+        }
+
+        @Test
+        void shouldReturnIdentityVariablesFromDifferentIdentities() throws Exception {
+            var service = new IdentityService(
+                    Map.of(),
+                    Map.of(
+                            "MockIdentity1",
+                            new Identity(null, null, Map.of("plain-key-1", "plain-value-1"),
+                                    new Plugin(TestableIdentityPlugin.class.getName(), Map.of())),
+                            "MockIdentity2",
+                            new Identity(null, null, Map.of("plain-key-2", "plain-value-2"),
+                                    new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
+
+            var variables1 = service.variablesFor("MockIdentity1");
+            var variables2 = service.variablesFor("MockIdentity2");
+
+            assertThat(variables1)
+                    .containsOnly(
+                            entry("plain-key-1", "plain-value-1"),
+                            entry("identity-plugin-key", "identity-plugin-value"));
+
+            assertThat(variables2)
+                    .containsOnly(
+                            entry("plain-key-2", "plain-value-2"),
+                            entry("identity-plugin-key", "identity-plugin-value"));
+        }
+
+        @Test
+        void shouldThrowWhenIdentityIsUnknown() {
+            var service = new IdentityService(
+                    Map.of(),
+                    Map.of("MockIdentity",
+                            new Identity(null, null, Map.of("plain-key", "plain-value"), null)));
+
+            assertThatExceptionOfType(NoSuchElementException.class)
+                    .isThrownBy(() -> service.variablesFor("UnknownIdentity"))
+                    .withMessage("Cannot find identity for 'UnknownIdentity'");
+        }
+
+        @Test
+        void shouldThrowWhenSecretIsUnknown() {
+            var service = new IdentityService(
+                    Map.of(),
+                    Map.of("MockIdentity",
+                            new Identity(null, "UnknownSecrets", Map.of("plain-key", "plain-value"), null)));
+
+            assertThatExceptionOfType(NoSuchElementException.class)
+                    .isThrownBy(() -> service.variablesFor("MockIdentity"))
+                    .withMessage("Cannot find secret plugin 'UnknownSecrets'");
+        }
+
+        @Test
+        void shouldThrowWhenIdentityPluginIsUnknown() {
+            var service = new IdentityService(
+                    Map.of(),
+                    Map.of("MockIdentity",
+                            new Identity(null, null, Map.of(),
+                                    new Plugin(UnknownIdentityPlugin.class.getName(), Map.of()))));
+
+            assertThatExceptionOfType(NoSuchElementException.class)
+                    .isThrownBy(() -> service.variablesFor("MockIdentity"))
+                    .withMessage(
+                            "Cannot find plugin 'io.blt.gregbot.core.services.IdentityServiceTest$UnknownIdentityPlugin'");
+        }
+
+        @Test
+        void shouldThrowWhenSecretPluginIsUnknown() {
+            var service = new IdentityService(
+                    Map.of("MockSecret",
+                            new Secret(new Plugin(UnknownSecretPlugin.class.getName(), Map.of()))),
+                    Map.of("MockIdentity",
+                            new Identity(null, "MockSecret", Map.of(),
+                                    new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
+
+            assertThatExceptionOfType(NoSuchElementException.class)
+                    .isThrownBy(() -> service.variablesFor("MockIdentity"))
+                    .withMessage(
+                            "Cannot find plugin 'io.blt.gregbot.core.services.IdentityServiceTest$UnknownSecretPlugin'");
+        }
+
+        @Nested
+        class PluginInstances {
+
+            @BeforeEach
+            void beforeEach() {
+                // I don't like having state between tests but the alternative that I see isn't much better; I can
+                // imagine pulling out the getOrComputeIdentityPlugin method to a class and testing its result. This is
+                // great, but it doesn't solve the same issue with SecretPlugin without adding a public method to expose
+                // it just for testing. Modifying the interface of an implementation for testing purposes opens the
+                // class to abuse and is worse in my opinion.
+                TestableIdentityPlugin.resetInstanceCount();
+                TestableSecretPlugin.resetInstanceCount();
+            }
+
+            @Test
+            void shouldUseSameInstanceOfIdentityPluginOnMultipleCalls() throws Exception {
+                var service = new IdentityService(
+                        Map.of(),
+                        Map.of("MockIdentity1",
+                                new Identity(null, null, Map.of(),
+                                        new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
+
+                service.variablesFor("MockIdentity1");
+                service.variablesFor("MockIdentity1");
+
+                assertThat(TestableIdentityPlugin.instanceCount())
+                        .isOne();
+            }
+
+            @Test
+            void shouldUseSameInstancesOfIdentityPluginForIdenticalIdentityProperties() throws Exception {
+                var service = new IdentityService(
+                        Map.of(),
+                        Map.of(
+                                "MockIdentity1",
+                                new Identity(null, null, Map.of(),
+                                        new Plugin(TestableIdentityPlugin.class.getName(), Map.of())),
+                                "MockIdentity2",
+                                new Identity(null, null, Map.of(),
+                                        new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
+
+                service.variablesFor("MockIdentity1");
+                service.variablesFor("MockIdentity2");
+
+                assertThat(TestableIdentityPlugin.instanceCount())
+                        .isOne();
+            }
+
+            @Test
+            void shouldUseDifferentInstanceOfIdentityPluginForDifferentIdentityProperties() throws Exception {
+                var plugin = new Plugin(TestableIdentityPlugin.class.getName(), Map.of());
+
+                var service = new IdentityService(
+                        Map.of(),
+                        Map.of(
+                                "MockIdentity1",
+                                new Identity(null, null, Map.of("k", "v"), plugin),
+                                "MockIdentity2",
+                                new Identity(null, null, Map.of("k", "different"), plugin)));
+
+                service.variablesFor("MockIdentity1");
+                service.variablesFor("MockIdentity2");
+
+                assertThat(TestableIdentityPlugin.instanceCount())
+                        .isEqualTo(2);
+            }
+
+            @Test
+            void shouldUseDifferentInstanceOfIdentityPluginForDifferentIdentityPluginProperties() throws Exception {
+                var service = new IdentityService(
+                        Map.of(),
+                        Map.of(
+                                "MockIdentity1",
+                                new Identity(null, null, Map.of(),
+                                        new Plugin(TestableIdentityPlugin.class.getName(), Map.of("k", "v"))),
+                                "MockIdentity2",
+                                new Identity(null, null, Map.of(),
+                                        new Plugin(TestableIdentityPlugin.class.getName(), Map.of("k", "different")))));
+
+                service.variablesFor("MockIdentity1");
+                service.variablesFor("MockIdentity2");
+
+                assertThat(TestableIdentityPlugin.instanceCount())
+                        .isEqualTo(2);
+            }
+
+            @Test
+            void shouldUseSameInstanceOfSecretPluginOnMultipleCalls() throws Exception {
+                var identityPlugin = new Plugin(TestableIdentityPlugin.class.getName(), Map.of());
+
+                var service = new IdentityService(
+                        Map.of("MockSecret",
+                                new Secret(new Plugin(TestableSecretPlugin.class.getName(), Map.of()))),
+                        Map.of(
+                                "MockIdentity1",
+                                new Identity(null, "MockSecret", Map.of(), identityPlugin),
+                                "MockIdentity2",
+                                new Identity(null, "MockSecret", Map.of(), identityPlugin)
+                        ));
+
+                service.variablesFor("MockIdentity1");
+                service.variablesFor("MockIdentity2");
+
+                assertThat(TestableSecretPlugin.instanceCount())
+                        .isOne();
+            }
+
+            @Test
+            void shouldUseSameInstancesOfSecretPluginForIdenticalSecretProperties() throws Exception {
+                var identityPlugin = new Plugin(TestableIdentityPlugin.class.getName(), Map.of());
+
+                var service = new IdentityService(
+                        Map.of(
+                                "MockSecret1",
+                                new Secret(new Plugin(TestableSecretPlugin.class.getName(), Map.of("k", "v"))),
+                                "MockSecret2",
+                                new Secret(new Plugin(TestableSecretPlugin.class.getName(), Map.of("k", "v")))),
+                        Map.of(
+                                "MockIdentity1",
+                                new Identity(null, "MockSecret1", Map.of(), identityPlugin),
+                                "MockIdentity2",
+                                new Identity(null, "MockSecret2", Map.of(), identityPlugin)));
+
+                service.variablesFor("MockIdentity1");
+                service.variablesFor("MockIdentity2");
+
+                assertThat(TestableSecretPlugin.instanceCount())
+                        .isOne();
+            }
+
+            @Test
+            void shouldUseDifferentInstancesOfSecretPluginForDifferentSecretPluginProperties() throws Exception {
+                var identityPlugin = new Plugin(TestableIdentityPlugin.class.getName(), Map.of());
+
+                var service = new IdentityService(
+                        Map.of(
+                                "MockSecret1",
+                                new Secret(new Plugin(TestableSecretPlugin.class.getName(), Map.of("k", "v"))),
+                                "MockSecret2",
+                                new Secret(new Plugin(TestableSecretPlugin.class.getName(), Map.of("k", "different")))),
+                        Map.of(
+                                "MockIdentity1",
+                                new Identity(null, "MockSecret1", Map.of(), identityPlugin),
+                                "MockIdentity2",
+                                new Identity(null, "MockSecret2", Map.of(), identityPlugin)));
+
+                service.variablesFor("MockIdentity1");
+                service.variablesFor("MockIdentity2");
+
+                assertThat(TestableSecretPlugin.instanceCount())
+                        .isEqualTo(2);
+            }
+
+        }
+
     }
 
-    @Test
-    void shouldLoadAndFindIdentityPluginWithSecretPlugin() throws IdentityServiceException {
-        var service = new IdentityService(
-                Map.of("SecretPlugin", new Secret(
-                        new Plugin(TestableSecretPlugin.class.getName(), Map.of()))),
-                Map.of("IdentityPlugin", new Identity(
-                        null, "SecretPlugin", Map.of(),
-                        new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
+    static class UnknownIdentityPlugin implements IdentityPlugin {
 
-        var result = service.find("IdentityPlugin");
+        @Override
+        public Map<String, String> variables() {
+            return Map.of();
+        }
 
-        assertThat(result)
-                .isNotEmpty().get()
-                .isInstanceOf(TestableIdentityPlugin.class);
+        @Override
+        public void load(Map<String, String> properties) {
+        }
     }
 
-    @Test
-    void shouldRenderSecret() throws IdentityServiceException {
-        var service = new IdentityService(
-                Map.of("SecretPlugin", new Secret(
-                        new Plugin(TestableSecretPlugin.class.getName(), Map.of()))),
-                Map.of("IdentityPlugin", new Identity(
-                        null, "SecretPlugin", Map.of(),
-                        new Plugin(TestableIdentityPlugin.class.getName(),
-                                Map.of("secret", "[my/secret/path/test-secret]")))));
+    static class UnknownSecretPlugin implements SecretPlugin {
+        @Override
+        public Map<String, String> secretsForPath(String path) {
+            return Map.of();
+        }
 
-        var result = (TestableIdentityPlugin) service.find("IdentityPlugin").get();
-
-        assertThat(result.loadedProperties())
-                .containsEntry("secret", "my/secret/path-test-value");
-    }
-
-    @Test
-    void findShouldReturnEmptyWhenSpecifiedIdentityDoesNotExist() throws IdentityServiceException {
-        var service = new IdentityService(Map.of(), Map.of());
-
-        var result = service.find("DoesNotExist");
-
-        assertThat(result)
-                .isEmpty();
-    }
-
-    @Test
-    void shouldThrowWhenSpecifiedSecretPluginDoesNotExist() {
-        var service = new IdentityService(
-                Map.of("SecretPlugin", new Secret(
-                        new Plugin(TestableSecretPlugin.class.getName(), Map.of()))),
-                Map.of("IdentityPlugin", new Identity(
-                        null, "DoesNotExist", Map.of(),
-                        new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
-
-        assertThatNullPointerException()
-                .isThrownBy(() -> service.find("IdentityPlugin"))
-                .withMessage("Cannot find secret plugin 'DoesNotExist'");
-    }
-
-    @Test
-    void shouldRaiseExceptionWhenIdentityPluginThrows() {
-        var service = new IdentityService(
-                Map.of(),
-                Map.of("IdentityPlugin", new Identity(
-                        null, null, Map.of(),
-                        new Plugin(ThrowOnLoadIdentityPlugin.class.getName(), Map.of()))));
-
-        assertThatExceptionOfType(IdentityServiceException.class)
-                .isThrownBy(() -> service.find("IdentityPlugin"))
-                .havingCause()
-                .isInstanceOf(PluginException.class)
-                .withMessage("identity plugin test load exception");
-    }
-
-    @Test
-    void shouldRaiseExceptionWhenSecretPluginThrows() {
-        var service = new IdentityService(
-                Map.of("SecretPlugin", new Secret(
-                        new Plugin(ThrowOnLoadSecretPlugin.class.getName(), Map.of()))),
-                Map.of("IdentityPlugin", new Identity(
-                        null, "SecretPlugin", Map.of(),
-                        new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
-
-        assertThatExceptionOfType(IdentityServiceException.class)
-                .isThrownBy(() -> service.find("IdentityPlugin"))
-                .havingCause()
-                .isInstanceOf(PluginException.class)
-                .withMessage("secret plugin test load exception");
+        @Override
+        public void load(Map<String, String> properties) {
+        }
     }
 
 }

--- a/src/test/java/io/blt/gregbot/core/services/IdentityServiceTest.java
+++ b/src/test/java/io/blt/gregbot/core/services/IdentityServiceTest.java
@@ -436,6 +436,7 @@ class IdentityServiceTest {
 
         @Override
         public void load(Map<String, String> properties) {
+            throw new UnsupportedOperationException();
         }
     }
 
@@ -447,6 +448,7 @@ class IdentityServiceTest {
 
         @Override
         public void load(Map<String, String> properties) {
+            throw new UnsupportedOperationException();
         }
     }
 

--- a/src/test/java/io/blt/gregbot/core/services/IdentityServiceTest.java
+++ b/src/test/java/io/blt/gregbot/core/services/IdentityServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 class IdentityServiceTest {
 
@@ -109,9 +110,9 @@ class IdentityServiceTest {
                         null, "DoesNotExist", Map.of(),
                         new Plugin(TestableIdentityPlugin.class.getName(), Map.of()))));
 
-        assertThatIllegalArgumentException()
+        assertThatNullPointerException()
                 .isThrownBy(() -> service.find("IdentityPlugin"))
-                .withMessage("Cannot find secret plugin DoesNotExist");
+                .withMessage("Cannot find secret plugin 'DoesNotExist'");
     }
 
     @Test

--- a/src/test/java/io/blt/gregbot/core/services/IdentityServiceTest.java
+++ b/src/test/java/io/blt/gregbot/core/services/IdentityServiceTest.java
@@ -32,8 +32,8 @@ class IdentityServiceTest {
     @Test
     void shouldNotLoadSecretPluginInCtor() {
         new IdentityService(
-                Map.of("SecretPlugin", new Secret(
-                        new Plugin(ThrowOnLoadSecretPlugin.class.getName(), Map.of()))),
+                Map.of("SecretPlugin",
+                        new Secret(new Plugin(ThrowOnLoadSecretPlugin.class.getName(), Map.of()))),
                 Map.of());
     }
 
@@ -41,9 +41,9 @@ class IdentityServiceTest {
     void shouldNotLoadIdentityPluginInCtor() {
         new IdentityService(
                 Map.of(),
-                Map.of("IdentityPlugin", new Identity(
-                        null, null, Map.of(),
-                        new Plugin(ThrowOnLoadIdentityPlugin.class.getName(), Map.of()))));
+                Map.of("IdentityPlugin",
+                        new Identity(null, null, Map.of(),
+                                new Plugin(ThrowOnLoadIdentityPlugin.class.getName(), Map.of()))));
     }
 
     @Nested

--- a/src/test/resources/META-INF/services/io.blt.gregbot.plugin.identities.IdentityPlugin
+++ b/src/test/resources/META-INF/services/io.blt.gregbot.plugin.identities.IdentityPlugin
@@ -1,2 +1,3 @@
 io.blt.gregbot.core.plugin.TestableIdentityPlugin
 io.blt.gregbot.core.plugin.ThrowOnLoadIdentityPlugin
+io.blt.gregbot.core.plugin.ThrowOnVariablesIdentityPlugin

--- a/src/test/resources/META-INF/services/io.blt.gregbot.plugin.secrets.SecretPlugin
+++ b/src/test/resources/META-INF/services/io.blt.gregbot.plugin.secrets.SecretPlugin
@@ -1,2 +1,3 @@
 io.blt.gregbot.core.plugin.TestableSecretPlugin
 io.blt.gregbot.core.plugin.ThrowOnLoadSecretPlugin
+io.blt.gregbot.core.plugin.ThrowOnSecretsForPathSecretPlugin


### PR DESCRIPTION
### Modify `IdentityService` to return resolved variables

Encapsulate all identity variable resolution (including plugin management, secret rendering, etc) into `IdentityService`.

This provides a one stop shop for a given identities variables, ready to be used.