### PR TITLE
Case insensitive enum properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <httpcore5.version>5.2.5</httpcore5.version>
         <jackson.version>2.17.2</jackson.version>
         <jakarta-el.version>5.0.0-M1</jakarta-el.version>
+        <jsonassert.version>1.5.3</jsonassert.version>
         <junit.version>5.10.3</junit.version>
         <mockito.version>5.12.0</mockito.version>
         <vault-driver.version>5.1.0</vault-driver.version>
@@ -133,6 +134,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>${jsonassert.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/blt/gregbot/core/properties/Properties.java
+++ b/src/main/java/io/blt/gregbot/core/properties/Properties.java
@@ -11,6 +11,7 @@ package io.blt.gregbot.core.properties;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Valid;
 import jakarta.validation.Validation;
@@ -160,10 +161,11 @@ public record Properties(
     }
 
     private static ObjectMapper buildMapper() {
-        return new ObjectMapper()
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE)
-                .registerModule(new PropertiesModule());
+        return JsonMapper.builder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .propertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE)
+                .addModule(new PropertiesModule())
+                .build();
     }
 
     private static Validator buildValidator() {

--- a/src/main/java/io/blt/gregbot/core/properties/Properties.java
+++ b/src/main/java/io/blt/gregbot/core/properties/Properties.java
@@ -9,6 +9,7 @@
 package io.blt.gregbot.core.properties;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -123,13 +124,14 @@ public record Properties(
     /**
      * Returns an instance of {@link Properties} created from a JSON resource file.
      * <p>
-     *     This method will:
+     * This method will:
      *     <ol>
      *         <li>Load the resource file</li>
      *         <li>Deserialize into {@link Properties} and nested {@code record}s</li>
      *         <li>Perform validation, throwing on failure</li>
      *     </ol>
      * </p>
+     *
      * @param filename resource file to load
      * @return instance of {@link Properties}
      * @throws IOException if the file cannot be read or there is a validation fails
@@ -163,6 +165,7 @@ public record Properties(
     private static ObjectMapper buildMapper() {
         return JsonMapper.builder()
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
                 .propertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE)
                 .addModule(new PropertiesModule())
                 .build();

--- a/src/test/java/io/blt/gregbot/core/properties/PropertiesTest.java
+++ b/src/test/java/io/blt/gregbot/core/properties/PropertiesTest.java
@@ -12,11 +12,15 @@ import jakarta.validation.Valid;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.stream.Stream;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.skyscreamer.jsonassert.JSONAssert;
 
+import static io.blt.test.TestUtils.loadAsString;
+import static io.blt.test.TestUtils.pojoToJson;
 import static io.blt.test.TestUtils.streamFieldsOfContainerTypes;
 import static io.blt.test.TestUtils.streamFieldsOfNestedTypes;
 import static io.blt.test.assertj.AnnotationAssertions.assertHasAnnotation;
@@ -108,6 +112,17 @@ class PropertiesTest {
 
         assertThat(layout.requests()).isUnmodifiable();
         assertThat(layout.folders().get("Emergency").requests()).isUnmodifiable();
+    }
+
+    @Test
+    void loadFromJsonShouldProduceObjectEqualToExpectedJson() throws IOException, JSONException {
+        var expected = loadAsString(getClass(), "full-expected.json");
+
+        var properties = Properties.loadFromJson("full.json");
+
+        var json = pojoToJson(properties);
+
+        JSONAssert.assertEquals(expected, json, true);
     }
 
 }

--- a/src/test/java/io/blt/test/TestUtils.java
+++ b/src/test/java/io/blt/test/TestUtils.java
@@ -8,6 +8,10 @@
 
 package io.blt.test;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Map;
@@ -44,6 +48,24 @@ public final class TestUtils {
     public static <T> Stream<Field> streamFieldsOfMapTypes(Class<T> type) {
         return Stream.of(type.getDeclaredFields())
                 .filter(f -> Map.class.isAssignableFrom(f.getType()));
+    }
+
+    public static <T> InputStream load(Class<T> type, String filename) {
+        return type.getResourceAsStream(filename);
+    }
+
+    public static <T> byte[] loadAsBytes(Class<T> type, String filename) throws IOException {
+        try (var stream = load(type, filename)) {
+            return stream.readAllBytes();
+        }
+    }
+
+    public static <T> String loadAsString(Class<T> type, String filename) throws IOException {
+        return new String(loadAsBytes(type, filename));
+    }
+
+    public static String pojoToJson(Object pojo) throws JsonProcessingException {
+        return new ObjectMapper().writeValueAsString(pojo);
     }
 
 }

--- a/src/test/resources/io/blt/gregbot/core/properties/full-expected.json
+++ b/src/test/resources/io/blt/gregbot/core/properties/full-expected.json
@@ -1,0 +1,162 @@
+{
+  "client": {
+    "version": "HTTP_1_1",
+    "redirect": "NORMAL",
+    "connectionTimeout": 30,
+    "requestTimeout": 60
+  },
+  "secrets": {
+    "Cyberdyne Vault": {
+      "plugin": {
+        "type": "io.blt.gregbot.plugin.VaultOidc",
+        "properties": {
+          "host": "https://vault.cyberdyne.com"
+        }
+      }
+    }
+  },
+  "environments": {
+    "Cyberdyne Local": {
+      "variables": {
+        "skynet_host": "http://localhost:8081"
+      }
+    },
+    "Cyberdyne Stage": {
+      "variables": {
+        "skynet_host": "https://stage-skynet.cyberdyne.com"
+      }
+    },
+    "Cyberdyne Prod": {
+      "variables": {
+        "skynet_host": "https://skynet.cyberdyne.com"
+      }
+    }
+  },
+  "identities": {
+    "Portfolio Stage": {
+      "category": "Stage",
+      "secrets": "Cyberdyne Vault",
+      "variables": {
+        "api_key": "atari-80C88"
+      },
+      "plugin": {
+        "type": "com.cyberdyne.gregbot.plugin.ImsService",
+        "properties": {
+          "host": "https://stage-ims.cyberdyne.com",
+          "secret": "[cyberdyne/portfolio/ims/stage/secret]",
+          "variable": "auth_token"
+        }
+      }
+    },
+    "Miles Dyson": {
+      "category": null,
+      "secrets": "Cyberdyne Vault",
+      "variables": {},
+      "plugin": {
+        "type": "com.cyberdyne.gregbot.plugin.ImsUser",
+        "properties": {
+          "host": "https://ims.cyberdyne.com",
+          "secret": "[cyberdyne/mdyson/ims/prod/secret]",
+          "variable": "auth_token"
+        }
+      }
+    }
+  },
+  "collections": {
+    "Skynet": {
+      "requests": {
+        "Health Check": {
+          "headers": {
+            "x-api-key": "{{api_key}}"
+          },
+          "verb": "GET",
+          "path": "{{skynet_host}}/ping"
+        },
+        "List Terminators": {
+          "headers": {
+            "x-api-key": "{{api_key}}"
+          },
+          "verb": "GET",
+          "path": "{{skynet_host}}/terminators"
+        },
+        "Fetch Terminator": {
+          "headers": {
+            "x-api-key": "{{api_key}}"
+          },
+          "verb": "GET",
+          "path": "{{skynet_host}}/terminators/{terminator_model}"
+        },
+        "Emergency Shutdown Terminator": {
+          "headers": {
+            "x-api-key": "{{api_key}}"
+          },
+          "verb": "DELETE",
+          "path": "{{skynet_host}}/terminators/{terminator_model}"
+        },
+        "List Aerials": {
+          "headers": {
+            "x-api-key": "{{api_key}}"
+          },
+          "verb": "GET",
+          "path": "{{skynet_host}}/aerials"
+        },
+        "Fetch Aerial": {
+          "headers": {
+            "x-api-key": "{{api_key}}"
+          },
+          "verb": "GET",
+          "path": "{{skynet_host}}/aerials/{aerial_model}"
+        },
+        "Emergency Shutdown Aerial": {
+          "headers": {
+            "x-api-key": "{{api_key}}"
+          },
+          "verb": "DELETE",
+          "path": "{{skynet_host}}/aerials/{terminator_model}"
+        }
+      },
+      "layout": {
+        "requests": [
+          "Health Check"
+        ],
+        "folders": {
+          "Terminator": {
+            "requests": [
+              "List Terminators",
+              "Fetch Terminator"
+            ],
+            "folders": {
+              "Emergency": {
+                "requests": [
+                  "Emergency Shutdown Terminator"
+                ],
+                "folders": {}
+              }
+            }
+          },
+          "Aerial": {
+            "requests": [
+              "List Aerials",
+              "Fetch Aerial"
+            ],
+            "folders": {
+              "Emergency": {
+                "requests": [
+                  "Emergency Shutdown Aerial"
+                ],
+                "folders": {}
+              }
+            }
+          },
+          "Emergency": {
+            "requests": [
+              "Emergency Shutdown Terminator",
+              "Emergency Shutdown Aerial"
+            ],
+            "folders": {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/io/blt/gregbot/core/properties/full.json
+++ b/src/test/resources/io/blt/gregbot/core/properties/full.json
@@ -67,7 +67,7 @@
           "headers": {
             "x-api-key": "{{api_key}}"
           },
-          "verb": "GET",
+          "verb": "get",
           "path": "{{skynet_host}}/ping"
         },
         "List Terminators": {
@@ -109,7 +109,7 @@
           "headers": {
             "x-api-key": "{{api_key}}"
           },
-          "verb": "DELETE",
+          "verb": "delete",
           "path": "{{skynet_host}}/aerials/{terminator_model}"
         }
       },


### PR DESCRIPTION
### Case insensitive enum properties

Allows the properties file to contain `enum` values of any case
e.g., `"verb": "GET"` and `"verb": "get"` are equivalent.