### PR TITLE
Set AWT headless in surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.awt.headless>true</java.awt.headless>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/test/java/io/blt/test/MockUi.java
+++ b/src/test/java/io/blt/test/MockUi.java
@@ -8,7 +8,6 @@
 
 package io.blt.test;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -21,11 +20,6 @@ public abstract class MockUi {
 
     @Mock
     protected Taskbar mockTaskbar;
-
-    @BeforeEach
-    void beforeEach() {
-        System.setProperty("java.awt.headless", "true");
-    }
 
     protected void doWithMockedUi(Runnable runnable) {
         try (var taskbar = Mockito.mockStatic(Taskbar.class)) {


### PR DESCRIPTION
### Set AWT headless in surefire plugin

Moving `java.awt.headless=true` from `MockUi` to Surefire plugin configuration.