### PR TITLE
Log unexpected exceptions in Ui

### DIFF
--- a/src/main/java/io/blt/gregbot/ui/Ui.java
+++ b/src/main/java/io/blt/gregbot/ui/Ui.java
@@ -21,32 +21,36 @@ import javax.swing.*;
 
 public class Ui {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Ui.class);
+    private final Logger log = LoggerFactory.getLogger(Ui.class);
 
     public static void start() {
-        LOG.info("Starting {} {}",
-                ApplicationProperties.name(),
-                ApplicationProperties.version());
-
         System.setProperty("apple.laf.useScreenMenuBar", "true");
         System.setProperty("apple.awt.application.name", ApplicationProperties.name());
         System.setProperty("apple.awt.application.appearance", "system");
-
-        if (Taskbar.getTaskbar().isSupported(Taskbar.Feature.ICON_IMAGE)) {
-            Taskbar.getTaskbar().setIconImage(ApplicationResources.largestIcon());
-        }
 
         SwingUtilities.invokeLater(Ui::new);
     }
 
     Ui() {
-        configureLookAndFeel();
+        log.info("Starting {} {}",
+                ApplicationProperties.name(),
+                ApplicationProperties.version());
 
-        new SplashScreen("/splash/octogreg/2048.png", 1500)
-                .setVisible(true);
+        try {
+            if (Taskbar.getTaskbar().isSupported(Taskbar.Feature.ICON_IMAGE)) {
+                Taskbar.getTaskbar().setIconImage(ApplicationResources.largestIcon());
+            }
 
-        var mainForm = new MainForm();
-        mainForm.setVisible(true);
+            configureLookAndFeel();
+
+            new SplashScreen("/splash/octogreg/2048.png", 1500)
+                    .setVisible(true);
+
+            var mainForm = new MainForm();
+            mainForm.setVisible(true);
+        } catch (Exception e) {
+            log.error("Unexpected exception", e);
+        }
     }
 
     private void configureLookAndFeel() {

--- a/src/test/java/io/blt/gregbot/ui/UiTest.java
+++ b/src/test/java/io/blt/gregbot/ui/UiTest.java
@@ -24,8 +24,10 @@ import org.slf4j.LoggerFactory;
 import static io.blt.test.MockUtils.captureSwingInvokeLaterWhile;
 import static io.blt.test.MockUtils.doWithMockedConstructor;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -87,6 +89,19 @@ class UiTest extends MockUi {
 
                 verify(mockTaskbar)
                         .setIconImage(ApplicationResources.largestIcon());
+            });
+        }
+
+        @Test
+        void shouldNotSetIconImageWhenNotSupported() {
+            doWithMockedUi(() -> {
+                when(mockTaskbar.isSupported(Taskbar.Feature.ICON_IMAGE))
+                        .thenReturn(false);
+
+                new Ui();
+
+                verify(mockTaskbar, never())
+                        .setIconImage(any());
             });
         }
 

--- a/src/test/java/io/blt/gregbot/ui/UiTest.java
+++ b/src/test/java/io/blt/gregbot/ui/UiTest.java
@@ -16,10 +16,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static io.blt.test.MockUtils.captureSwingInvokeLaterWhile;
 import static io.blt.test.MockUtils.doWithMockedConstructor;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,21 +35,6 @@ class UiTest extends MockUi {
 
     @Nested
     class Start {
-
-        @Test
-        void shouldUseInvokeLaterToCallUiConstructor() {
-            doWithMockedUi(() -> {
-                var invokeLater = captureSwingInvokeLaterWhile(Ui::start)
-                        .getValue();
-
-                doWithMockedConstructor(Ui.class, ctor -> {
-                    invokeLater.run();
-
-                    assertThat(ctor.constructed())
-                            .hasSize(1);
-                });
-            });
-        }
 
         static Stream<Arguments> shouldSetPropertiesToSupportMacOs() {
             return Stream.of(
@@ -67,16 +58,56 @@ class UiTest extends MockUi {
         }
 
         @Test
+        void shouldUseInvokeLaterToCallUiConstructor() {
+            doWithMockedUi(() -> {
+                var invokeLater = captureSwingInvokeLaterWhile(Ui::start)
+                        .getValue();
+
+                doWithMockedConstructor(Ui.class, ctor -> {
+                    invokeLater.run();
+
+                    assertThat(ctor.constructed())
+                            .hasSize(1);
+                });
+            });
+        }
+
+    }
+
+    @Nested
+    class Constructor {
+
+        @Test
         void shouldSetIconImageWhenSupported() {
             doWithMockedUi(() -> {
-               when(mockTaskbar.isSupported(Taskbar.Feature.ICON_IMAGE))
-                       .thenReturn(true);
+                when(mockTaskbar.isSupported(Taskbar.Feature.ICON_IMAGE))
+                        .thenReturn(true);
 
-               Ui.start();
+                new Ui();
 
-               verify(mockTaskbar)
-                       .setIconImage(ApplicationResources.largestIcon());
+                verify(mockTaskbar)
+                        .setIconImage(ApplicationResources.largestIcon());
             });
+        }
+
+        @Test
+        void shouldLogUnexpectedExceptions() {
+            try (var loggerFactory = Mockito.mockStatic(LoggerFactory.class)) {
+                var logger = mock(Logger.class);
+
+                loggerFactory.when(() -> LoggerFactory.getLogger(Ui.class))
+                        .thenReturn(logger);
+
+                // This will inherently throw because the tests are running in headless mode
+                new Ui();
+
+                var exception = ArgumentCaptor.forClass(Exception.class);
+                verify(logger)
+                        .error(eq("Unexpected exception"), exception.capture());
+
+                assertThat(exception.getValue())
+                        .isInstanceOf(HeadlessException.class);
+            }
         }
 
     }


### PR DESCRIPTION
### Log unexpected exceptions in Ui

This is also an opportunity to set properties before Swing is initialised via `DocumentAppender`
e.g., `apple.awt.application.name`